### PR TITLE
renamed AlignedBlock to match c++

### DIFF
--- a/src/structs/block_based_image.rs
+++ b/src/structs/block_based_image.rs
@@ -18,10 +18,10 @@ pub struct BlockBasedImage {
 
     dpos_offset: i32,
 
-    image: Vec<ExpandedBlockData>,
+    image: Vec<AlignedBlock>,
 }
 
-static EMPTY: ExpandedBlockData = ExpandedBlockData { raw_data: [0; 64] };
+static EMPTY: AlignedBlock = AlignedBlock { raw_data: [0; 64] };
 
 impl BlockBasedImage {
     // constructs new block image for the given y-coordinate range
@@ -130,18 +130,18 @@ impl BlockBasedImage {
             if self.image.len() >= self.image.capacity() {
                 panic!("out of memory");
             }
-            self.image.push(ExpandedBlockData { raw_data: [0; 64] });
+            self.image.push(AlignedBlock { raw_data: [0; 64] });
         }
     }
 
     pub fn set_block_data(&mut self, dpos: i32, block_data: &[i16; 64]) {
         self.fill_up_to_dpos(dpos);
-        self.image[(dpos - self.dpos_offset) as usize] = ExpandedBlockData {
+        self.image[(dpos - self.dpos_offset) as usize] = AlignedBlock {
             raw_data: *block_data,
         };
     }
 
-    pub fn get_block(&self, dpos: i32) -> &ExpandedBlockData {
+    pub fn get_block(&self, dpos: i32) -> &AlignedBlock {
         if (dpos - self.dpos_offset) as usize >= self.image.len() {
             return &EMPTY;
         } else {
@@ -149,17 +149,19 @@ impl BlockBasedImage {
         }
     }
 
-    pub fn get_block_mut(&mut self, dpos: i32) -> &mut ExpandedBlockData {
+    pub fn get_block_mut(&mut self, dpos: i32) -> &mut AlignedBlock {
         self.fill_up_to_dpos(dpos);
         return &mut self.image[(dpos - self.dpos_offset) as usize];
     }
 }
 
-pub struct ExpandedBlockData {
+/// block of 64 coefficients in the aligned order, which is similar to zigzag except that the 7x7 lower right square comes first,
+/// followed by the DC, followed by the edges
+pub struct AlignedBlock {
     raw_data: [i16; 64],
 }
 
-impl ExpandedBlockData {
+impl AlignedBlock {
     pub fn get_dc(&self) -> i16 {
         return self.raw_data[ALIGNED_BLOCK_INDEX_DC_INDEX];
     }

--- a/src/structs/block_context.rs
+++ b/src/structs/block_context.rs
@@ -4,7 +4,7 @@
  *  This software incorporates material from third parties. See Notices.txt for details.
  *----------------------------------------/----------------------------------------------------*/
 
-use super::block_based_image::{BlockBasedImage, ExpandedBlockData};
+use super::block_based_image::{BlockBasedImage, AlignedBlock};
 use super::neighbor_summary::NeighborSummary;
 
 pub struct BlockContext {
@@ -66,27 +66,27 @@ impl BlockContext {
         };
     }
 
-    pub fn here<'a>(&self, image_data: &'a BlockBasedImage) -> &'a ExpandedBlockData {
+    pub fn here<'a>(&self, image_data: &'a BlockBasedImage) -> &'a AlignedBlock {
         let retval = image_data.get_block(self.cur_block_index);
         return retval;
     }
 
-    pub fn here_mut<'a>(&self, image_data: &'a mut BlockBasedImage) -> &'a mut ExpandedBlockData {
+    pub fn here_mut<'a>(&self, image_data: &'a mut BlockBasedImage) -> &'a mut AlignedBlock {
         let retval = image_data.get_block_mut(self.cur_block_index);
         return retval;
     }
 
-    pub fn left<'a>(&self, image_data: &'a BlockBasedImage) -> &'a ExpandedBlockData {
+    pub fn left<'a>(&self, image_data: &'a BlockBasedImage) -> &'a AlignedBlock {
         let retval = image_data.get_block(self.cur_block_index - 1);
         return retval;
     }
 
-    pub fn above<'a>(&self, image_data: &'a BlockBasedImage) -> &'a ExpandedBlockData {
+    pub fn above<'a>(&self, image_data: &'a BlockBasedImage) -> &'a AlignedBlock {
         let retval = image_data.get_block(self.above_block_index);
         return retval;
     }
 
-    pub fn above_left<'a>(&self, image_data: &'a BlockBasedImage) -> &'a ExpandedBlockData {
+    pub fn above_left<'a>(&self, image_data: &'a BlockBasedImage) -> &'a AlignedBlock {
         let retval = image_data.get_block(self.above_block_index - 1);
         return retval;
     }

--- a/src/structs/idct.rs
+++ b/src/structs/idct.rs
@@ -4,7 +4,7 @@
  *  This software incorporates material from third parties. See Notices.txt for details.
  *----------------------------------------/----------------------------------------------------*/
 
-use super::block_based_image::ExpandedBlockData;
+use super::block_based_image::AlignedBlock;
 
 use wide::i32x8;
 
@@ -32,7 +32,7 @@ const R2: i32 = 181; // 256/sqrt(2)
 fn get_raster<const IGNORE_DC: bool>(
     offset: usize,
     stride: usize,
-    block: &ExpandedBlockData,
+    block: &AlignedBlock,
 ) -> i32x8 {
     return i32x8::new([
         block.get_coefficient_raster(7 * stride + offset) as i32,
@@ -100,7 +100,7 @@ fn transpose(
 
 #[inline(never)]
 pub fn run_idct<const IGNORE_DC: bool>(
-    block: &ExpandedBlockData,
+    block: &AlignedBlock,
     q: &[u16; 64],
     outp: &mut [i16; 64],
 ) {
@@ -219,7 +219,7 @@ pub fn run_idct<const IGNORE_DC: bool>(
 use std::num::Wrapping;
 
 #[cfg(feature = "verify_old_dct")]
-fn verify_behavior(block: &ExpandedBlockData, q: &[u16; 64], new_outp: &[i16; 64]) -> bool {
+fn verify_behavior(block: &AlignedBlock, q: &[u16; 64], new_outp: &[i16; 64]) -> bool {
     let mut outp_orig = [0; 64];
     run_idct_old(block, q, &mut outp_orig, true);
 
@@ -233,7 +233,7 @@ fn mul(a: i16, b: u16) -> Wrapping<i32> {
 
 #[cfg(feature = "verify_old_dct")]
 pub fn run_idct_old(
-    block: &ExpandedBlockData,
+    block: &AlignedBlock,
     q: &[u16; 64],
     outp: &mut [i16; 64],
     ignore_dc: bool,

--- a/src/structs/jpeg_read.rs
+++ b/src/structs/jpeg_read.rs
@@ -39,7 +39,7 @@ use std::io::Read;
 use crate::here;
 
 use super::bit_reader::BitReader;
-use super::block_based_image::{BlockBasedImage, ExpandedBlockData};
+use super::block_based_image::{BlockBasedImage, AlignedBlock};
 use super::jpeg_position_state::JpegPositionState;
 use super::lepton_format::LeptonHeader;
 use super::thread_handoff::ThreadHandoff;
@@ -388,7 +388,7 @@ fn decode_baseline_rst<R: Read>(
         // prepare zigzagged block
         let mut zzblock = [0i16; 64];
         for bpos in 0..eob {
-            ExpandedBlockData::set_coefficient_zigzag_block(&mut zzblock, bpos as u8, block[bpos]);
+            AlignedBlock::set_coefficient_zigzag_block(&mut zzblock, bpos as u8, block[bpos]);
         }
 
         // set block data


### PR DESCRIPTION
Had changed the name at some intermediate point, but now rename back to match what the C++ code had to avoid confusion.