### PR TITLE
improved inner loop of Huffman reading

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -46,7 +46,7 @@ pub fn buffer_prefix_matches_marker<const BS: usize, const MS: usize>(
 }
 
 #[inline(always)]
-pub const fn devli(s: u8, value: u32) -> i16 {
+pub const fn devli(s: u8, value: u16) -> i16 {
     if s == 0 {
         value as i16
     } else if value < (1 << (s as u16 - 1)) {

--- a/src/structs/bit_reader.rs
+++ b/src/structs/bit_reader.rs
@@ -37,7 +37,7 @@ impl<R: Read> BitReader<R> {
     }
 
     #[inline(always)]
-    pub fn read(&mut self, bits_to_read: u8) -> std::io::Result<u32> {
+    pub fn read(&mut self, bits_to_read: u8) -> std::io::Result<u16> {
         if bits_to_read == 0 {
             return Ok(0);
         }
@@ -46,7 +46,7 @@ impl<R: Read> BitReader<R> {
             self.fill_register(bits_to_read)?;
         }
 
-        let retval = ((self.bits >> (64 - bits_to_read)) & ((1 << bits_to_read) - 1)) as u32;
+        let retval = ((self.bits >> (64 - bits_to_read)) & ((1 << bits_to_read) - 1)) as u16;
         self.bits <<= bits_to_read as usize;
         self.num_bits -= bits_to_read;
         return Ok(retval);
@@ -155,7 +155,7 @@ impl<R: Read> BitReader<R> {
                 }
                 Some(x) => {
                     // if we already saw a padding, then it should match
-                    let expected = u32::from(x) & all_one;
+                    let expected = u16::from(x) & all_one;
                     if actual != expected {
                         return err_exit_code(ExitCode::UnsupportedJpeg, format!("padding of {0} bits should be set to 1 actual={1:b} expected={2:b}", num_bits_to_read, actual, expected).as_str());
                     }

--- a/src/structs/jpeg_write.rs
+++ b/src/structs/jpeg_write.rs
@@ -577,7 +577,7 @@ fn encode_eobrun(huffw: &mut BitWriter, actbl: &HuffCodes, state: &mut JpegPosit
 /// encodes the correction bits, which are simply encoded as a vector of single bit values
 fn encode_crbits(huffw: &mut BitWriter, correction_bits: &mut Vec<u8>) {
     for x in correction_bits.drain(..) {
-        huffw.write(x as u32, 1);
+        huffw.write(u32::from(x), 1);
     }
 }
 


### PR DESCRIPTION
Remove a branch in huffman code reading and make both left and right points be in the same memory line. About 2.5% improvement -verify end-to-end