### PR TITLE
Fix a couple issues found by fuzzer

### DIFF
--- a/fuzz/fuzz_targets/fuzz_target_1.rs
+++ b/fuzz/fuzz_targets/fuzz_target_1.rs
@@ -17,8 +17,8 @@ fuzz_target!(|data: &[u8]| {
         // keep the jpeg dimensions small otherwise the fuzzer gets really slow
         let features = EnabledFeatures {
             progressive: true,
-            max_jpeg_height: 131,
-            max_jpeg_width: 131,
+            max_jpeg_height: 1024,
+            max_jpeg_width: 1024,
         };
 
         r = encode_lepton_feat(&mut Cursor::new(&data), &mut writer, 8, &features);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -76,12 +76,13 @@ impl Metrics {
             let name = format!("{0:?}", x.0);
 
             println!(
-                "{0:16} total_bits={1:9} compressed_bits={2:9} ratio={3:4} (global improvement {4:10} bytes ({5:0.2}%)",
+                "{0:16} total_bits={1:9} compressed_bits={2:9} ratio={3:4} comp_delta={4:10}k storage={5:0.1}%, comp={6:0.2}%)",
                 name,
                 x.1.total_bits,
                 x.1.total_compressed,
                 x.1.total_compressed * 100 / x.1.total_bits,
-                (x.1.total_bits - x.1.total_compressed)/8,
+                (x.1.total_bits - x.1.total_compressed)/(8*1024),
+                (x.1.total_compressed as f64) * 100f64 / (total_compressed as f64),
                 ((x.1.total_bits - x.1.total_compressed) as f64)/(total_compressed as f64)*100f64
             );
         }

--- a/src/structs/jpeg_header.rs
+++ b/src/structs/jpeg_header.rs
@@ -482,6 +482,11 @@ impl JPegHeader {
             jpeg_code::SOF1| // SOF1 segment, coding process: extended sequential DCT
             jpeg_code::SOF2 =>  // SOF2 segment, coding process: progressive DCT
             {
+                if self.jpeg_type != JPegType::Unknown
+                {
+                    return err_exit_code(ExitCode::UnsupportedJpeg, "image cannot have multiple SOF blocks");
+                }
+
                 // set JPEG coding type
                 if btype == jpeg_code::SOF2
                 {

--- a/src/structs/jpeg_read.rs
+++ b/src/structs/jpeg_read.rs
@@ -230,6 +230,17 @@ pub fn read_progressive_scan<R: Read>(
         } else {
             // ---> progressive AC encoding <---
 
+            if jf.cs_from == 0 || jf.cs_to >= 64 || jf.cs_from >= jf.cs_to {
+                return err_exit_code(
+                    ExitCode::UnsupportedJpeg,
+                    format!(
+                        "progressive encoding range was invalid {0} to {1}",
+                        jf.cs_from, jf.cs_to
+                    )
+                    .as_str(),
+                );
+            }
+
             // only need AC
             jf.verify_huffman_table(false, true).context(here!())?;
 

--- a/src/structs/jpeg_read.rs
+++ b/src/structs/jpeg_read.rs
@@ -82,6 +82,9 @@ pub fn read_scan<R: Read>(
             )
             .context(here!())?;
         } else if jf.cs_to == 0 && jf.cs_sah == 0 {
+            // only need DC
+            jf.verify_huffman_table(true, false).context(here!())?;
+
             let mut last_dc = [0i16; 4];
 
             while sta == JPegDecodeStatus::DecodeInProgress {

--- a/src/structs/lepton_format.rs
+++ b/src/structs/lepton_format.rs
@@ -265,6 +265,9 @@ fn run_lepton_decoder_threads<R: Read + Seek, P: Send>(
     let mut qt = Vec::new();
     for i in 0..lh.jpeg_header.cmpc {
         let qtables = QuantizationTables::new(&lh.jpeg_header, i);
+
+        // check to see if quantitization table was properly initialized
+        // (table contains divisors for coefficients so it never should have a zero)
         if qtables.get_quantization_table()[0] == 0 {
             return err_exit_code(ExitCode::UnsupportedJpeg, "Quantization table is missing");
         }
@@ -473,6 +476,9 @@ fn run_lepton_encoder_threads<W: Write + Seek>(
     let mut quantization_tables = Vec::new();
     for i in 0..image_data.len() {
         let qtables = QuantizationTables::new(jpeg_header, i);
+
+        // check to see if quantitization table was properly initialized
+        // (table contains divisors for coefficients so it never should have a zero)
         if qtables.get_quantization_table()[0] == 0 {
             return err_exit_code(ExitCode::UnsupportedJpeg, "Quantization table is missing");
         }

--- a/src/structs/lepton_format.rs
+++ b/src/structs/lepton_format.rs
@@ -157,7 +157,8 @@ pub fn read_jpeg<R: Read + Seek>(
 
     let mut end_scan = reader.stream_position()? as i32;
 
-    if thread_handoff.len() == 0 {
+    // need at least two bytes of scan data
+    if start_scan + 2 > end_scan || thread_handoff.len() == 0 {
         return err_exit_code(
             ExitCode::UnsupportedJpeg,
             "couldnt find any sections to encode",

--- a/src/structs/lepton_format.rs
+++ b/src/structs/lepton_format.rs
@@ -264,7 +264,11 @@ fn run_lepton_decoder_threads<R: Read + Seek, P: Send>(
     let pts = ProbabilityTablesSet::new();
     let mut qt = Vec::new();
     for i in 0..lh.jpeg_header.cmpc {
-        qt.push(QuantizationTables::new(&lh.jpeg_header, i));
+        let qtables = QuantizationTables::new(&lh.jpeg_header, i);
+        if qtables.get_quantization_table()[0] == 0 {
+            return err_exit_code(ExitCode::UnsupportedJpeg, "Quantization table is missing");
+        }
+        qt.push(qtables);
     }
 
     let r = thread::scope(|s| -> Result<(Metrics, Vec<P>)> {
@@ -468,7 +472,11 @@ fn run_lepton_encoder_threads<W: Write + Seek>(
     let pts = ProbabilityTablesSet::new();
     let mut quantization_tables = Vec::new();
     for i in 0..image_data.len() {
-        quantization_tables.push(QuantizationTables::new(jpeg_header, i));
+        let qtables = QuantizationTables::new(jpeg_header, i);
+        if qtables.get_quantization_table()[0] == 0 {
+            return err_exit_code(ExitCode::UnsupportedJpeg, "Quantization table is missing");
+        }
+        quantization_tables.push(qtables);
     }
 
     let pts_ref = &pts;


### PR DESCRIPTION
Add additional validation to reject invalid huffman tables and require a minimum amount of scan data before compressing.