### PR TITLE
optimize branch update with small lookup tables

### DIFF
--- a/src/structs/branch.rs
+++ b/src/structs/branch.rs
@@ -48,7 +48,7 @@ const fn problookup() -> [u8; 65536] {
     return retval;
 }
 
-const PROB_LOOKUP: [u8; 65536] = problookup();
+static PROB_LOOKUP: [u8; 65536] = problookup();
 
 const fn truelookup() -> [u16; 256] {
     let mut retval = [0; 256];
@@ -66,7 +66,7 @@ const fn truelookup() -> [u16; 256] {
     retval
 }
 
-const NORMALIZE_TRUE: [u16; 256] = truelookup();
+static NORMALIZE_TRUE: [u16; 256] = truelookup();
 
 const fn falselookup() -> [u16; 256] {
     let mut retval = [0; 256];
@@ -88,7 +88,7 @@ const fn falselookup() -> [u16; 256] {
     retval
 }
 
-const NORMALIZE_FALSE: [u16; 256] = falselookup();
+static NORMALIZE_FALSE: [u16; 256] = falselookup();
 
 impl Branch {
     pub fn new() -> Self {
@@ -137,7 +137,6 @@ impl Branch {
             // non-overflow case is easy
             self.counts = self.counts.wrapping_add(0x100);
         } else {
-            // special case where it is all falses
             self.counts = NORMALIZE_FALSE[(self.counts & 0xff) as usize];
         }
     }

--- a/src/structs/branch.rs
+++ b/src/structs/branch.rs
@@ -117,7 +117,7 @@ impl Branch {
     pub fn record_and_update_true_obs(&mut self) {
         // do a wrapping subtraction so that we can catch both the case
         // where counts is zero (special case for many trues in a row), or
-        // 0xff in which case we need to normalize
+        // 0x**ff in which case we need to normalize
         // The adjustment to handle zero is handled in the lookup table
         if (self.counts & 0xff).wrapping_sub(1) < 0xfe {
             // non-overflow case is easy
@@ -131,7 +131,7 @@ impl Branch {
     pub fn record_and_update_false_obs(&mut self) {
         // do a wrapping subtraction so that we can catch both the case
         // where counts is zero (special case for many trues in a row), or
-        // 0xff00 in which case we need to normalize.
+        // 0xff** in which case we need to normalize.
         // The adjustment to handle zero is handled in the lookup table
         if self.counts.wrapping_sub(1) < 0xff00 {
             // non-overflow case is easy

--- a/src/structs/branch.rs
+++ b/src/structs/branch.rs
@@ -206,7 +206,7 @@ fn test_all_probabilities() {
         };
 
         if old_f.true_count() == 0 || old_f.false_count() == 0 {
-            // ignore the special case where counts is zero which is invalid
+            // counts can't be zero (we use 0 as an internal special value for the new implementation for the edge case of many trues in a row)
             continue;
         }
 


### PR DESCRIPTION
Use small lookup table to avoid branching during probability updates 