### PR TITLE
Make compression utility to always verify output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,9 +266,10 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lepton_jpeg"
-version = "0.1.2"
+version = "0.2.0"
 dependencies = [
  "anyhow",
+ "atty",
  "byteorder",
  "cpu-time",
  "default-boxed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lepton_jpeg"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 authors = ["Kristof Roomp <kristofr@microsoft.com>"]
 
@@ -34,6 +34,7 @@ wide = "0.7.5"
 log = "0.4.17"
 simple_logger ="4.0.0"
 cpu-time = "1.0.0"
+atty = "0.2.14"
 
 [dev-dependencies]
 rstest = "0.16.0"

--- a/package/Lepton.Jpeg.Rust.nuspec
+++ b/package/Lepton.Jpeg.Rust.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Lepton.Jpeg.Rust</id>
-    <version>0.0.2</version>
+    <version>0.2.0</version>
     <title>Lepton JPEG Compression Rust version binaries and libraries</title>
     <authors>kristofr</authors>
     <owners>kristofr</owners>

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use structs::lepton_format::read_jpeg;
 
 use std::{
     env,
-    fs::File,
+    fs::{File, OpenOptions},
     io::{BufReader, Cursor, Read, Seek, Write},
     time::Duration,
 };
@@ -51,6 +51,7 @@ fn main_with_result() -> anyhow::Result<()> {
     let mut iterations = 1;
     let mut dump = false;
     let mut all = false;
+    let mut overwrite = false;
     let mut enabled_features = EnabledFeatures::default();
 
     // only output the log if we are connected to a console (otherwise if there is redirection we would corrupt the file)
@@ -68,6 +69,8 @@ fn main_with_result() -> anyhow::Result<()> {
                 dump = true;
             } else if args[i] == "-all" {
                 all = true;
+            } else if args[i] == "-overwrite" {
+                overwrite = true;
             } else if args[i] == "-noprogressive" {
                 enabled_features.progressive = false;
             } else {
@@ -233,7 +236,12 @@ fn main_with_result() -> anyhow::Result<()> {
             .context(here!())?
     } else {
         let output_file: String = filenames[1].to_owned();
-        let mut fileout = File::create(output_file.as_str()).context(here!())?;
+        let mut fileout = OpenOptions::new()
+            .write(true)
+            .create(overwrite)
+            .create_new(!overwrite)
+            .open(output_file.as_str())
+            .context(here!())?;
 
         fileout.write_all(&output_data[..]).context(here!())?
     }

--- a/src/structs/lepton_format.rs
+++ b/src/structs/lepton_format.rs
@@ -102,18 +102,12 @@ pub fn encode_lepton_wrapper_verify(
 ) -> Result<(Vec<u8>, Metrics)> {
     let mut output_data = Vec::with_capacity(input_data.len());
 
-    if input_data.len() < 2 {
-        return err_exit_code(ExitCode::BadLeptonFile, "ERROR input file too small");
-    }
-
-    let mut metrics;
-
     info!("compressing to Lepton format");
 
     let mut reader = Cursor::new(&input_data);
     let mut writer = Cursor::new(&mut output_data);
 
-    metrics = encode_lepton_wrapper(
+    let mut metrics = encode_lepton_wrapper(
         &mut reader,
         &mut writer,
         max_threads as usize,
@@ -124,13 +118,12 @@ pub fn encode_lepton_wrapper_verify(
     // decode and compare to original in order to enure we encoded correctly
 
     let mut verify_buffer = Vec::with_capacity(input_data.len());
-    let mut verifyreader = Cursor::new(&output_data);
-    let mut verifywriter = Cursor::new(&mut verify_buffer);
+    let mut verifyreader = Cursor::new(&output_data[..]);
 
     info!("decompressing to verify contents");
 
     metrics.merge_from(
-        decode_lepton_wrapper(&mut verifyreader, &mut verifywriter, max_threads)
+        decode_lepton_wrapper(&mut verifyreader, &mut verify_buffer, max_threads)
             .context(here!())?,
     );
 


### PR DESCRIPTION
- Ensure that compression always verifies the roundtrip of the output 
- Don't overwrite the target file unless -overwrite is specified
- Improve logging a bit by removing useless statements and putting more useful info
- Support redirection of input and output (this turns off logging since it would corrupt stdout)