### PR TITLE
make split calculation the same across reader and writer

### DIFF
--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -138,12 +138,12 @@ impl<R: Read> VPXBoolReader<R> {
             self.vpx_reader_fill()?;
         }
 
-        let prob = branch.get_probability() as u32;
+        let probability = branch.get_probability() as u32;
 
         let mut tmp_range = self.range;
         let mut tmp_value = self.value;
 
-        let split = ((tmp_range * prob) + (256 - prob)) >> BITS_IN_BYTE;
+        let split = 1 + (((tmp_range - 1) * probability) >> BITS_IN_BYTE);
         let big_split = (split as u64) << BITS_IN_LONG_MINUS_LAST_BYTE;
         let bit = tmp_value >= big_split;
 

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -147,18 +147,20 @@ impl<R: Read> VPXBoolReader<R> {
         let big_split = (split as u64) << BITS_IN_LONG_MINUS_LAST_BYTE;
         let bit = tmp_value >= big_split;
 
+        let shift;
         if bit {
             branch.record_and_update_true_obs();
-            tmp_range = tmp_range - split;
+            tmp_range -= split;
             tmp_value -= big_split;
+
+            shift = (tmp_range as u8).leading_zeros() as i32;
         } else {
             branch.record_and_update_false_obs();
             tmp_range = split;
-        }
 
-        //lookup tables are best avoided in modern CPUs
-        //let shift = VPX_NORM[tmp_range as usize] as i32;
-        let shift = (tmp_range as u8).leading_zeros() as i32;
+            // optimizer understands that split > 0, so it can optimize this
+            shift = (split as u8).leading_zeros() as i32;
+        }
 
         self.value = tmp_value << shift;
         self.count -= shift;


### PR DESCRIPTION
this also allows the optimizer to understand that split will always be > 0, which improve the perf of the leading_zeros