### PR TITLE
use builtin cursor class for faster reading

### DIFF
--- a/src/structs/branch.rs
+++ b/src/structs/branch.rs
@@ -100,9 +100,9 @@ impl Branch {
             return;
         }
 
-        if (self.counts & 0xff00) != 0xff00 {
-            // non-overflow case is easy
-            self.counts += 0x100;
+        let (result, overflow) = self.counts.overflowing_add(0x100);
+        if !overflow {
+            self.counts = result;
         } else {
             // special case where it is all falses
             if self.counts != 0xff01 {

--- a/src/structs/branch.rs
+++ b/src/structs/branch.rs
@@ -68,28 +68,24 @@ impl Branch {
 
     #[inline(always)]
     pub fn get_probability(&self) -> u8 {
-        // 0 is a special corner case which should return probability 0
-        // since 0 is impossible to happen since the counts always start at 1
+        // 0x00ff is a special corner case which should return probability 0
+        // since 0x00ff is impossible to happen since the counts always start at 1
         PROB_LOOKUP[self.counts as usize]
     }
 
     #[inline(always)]
     pub fn record_and_update_true_obs(&mut self) {
-        if self.counts == 0 {
-            return; // no need to do anything since we are already as baised towards all trues as possible
-        }
-
         if (self.counts & 0xff) != 0xff {
             // non-overflow case is easy
             self.counts += 1;
         } else {
             // special case where it is all trues
-            if self.counts == 0x01ff {
+            if self.counts <= 0x01ff {
                 // corner case since the original implementation
                 // insists on setting the probabily to zero,
                 // although the probability calculation would
                 // return 1.
-                self.counts = 0;
+                self.counts = 0x00ff;
             } else {
                 self.counts = (((self.counts as u32 + 0x100) >> 1) & 0xff00) as u16 | 129;
             }
@@ -98,8 +94,8 @@ impl Branch {
 
     #[inline(always)]
     pub fn record_and_update_false_obs(&mut self) {
-        if self.counts == 0 {
-            // handle corner case where prob was set badly
+        if self.counts == 0x00ff {
+            // handle corner case where prob was set to zero (purely for compatibility, remove this if there is a breaking change in the format)
             self.counts = 0x02ff;
             return;
         }
@@ -109,8 +105,7 @@ impl Branch {
             self.counts += 0x100;
         } else {
             // special case where it is all falses
-            if self.counts == 0xff01 {
-            } else {
+            if self.counts != 0xff01 {
                 self.counts = ((1 + (self.counts & 0xff) as u32) >> 1) as u16 | 0x8100;
             }
         }

--- a/src/structs/lepton_format.rs
+++ b/src/structs/lepton_format.rs
@@ -400,7 +400,7 @@ fn run_lepton_decoder_threads<R: Read + Seek, P: Send>(
                     let rx = rx_channels[thread_id - start].take().context(here!())?;
                     let mut reader = MessageReceiver {
                         thread_id: thread_id as u8,
-                        current_buffer: None,
+                        current_buffer: Cursor::new(Vec::new()),
                         receiver: rx,
                         end_of_file: false,
                     };
@@ -1480,36 +1480,48 @@ impl Write for MessageSender {
     }
 }
 
+/// used by the worker thread to read data for the given thread from the
+/// receiver. The thread_id is used only to assert that we are only
+/// getting the data that we are expecting
 struct MessageReceiver {
+    /// the multiplexed thread stream we are processing
     thread_id: u8,
+
+    /// the receiver part of the channel to get more buffers
     receiver: Receiver<Message>,
-    current_buffer: Option<Cursor<Vec<u8>>>,
+
+    /// what we are reading. When this returns zero, we try to
+    /// refill the buffer if we haven't reached the end of the stream
+    current_buffer: Cursor<Vec<u8>>,
+
+    /// once we get told we are at the end of the stream, we just
+    /// always return 0 bytes
     end_of_file: bool,
 }
 
 impl Read for MessageReceiver {
+    /// fast path for reads. If we get zero bytes, take the slow path
     #[inline(always)]
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if let Some(x) = &mut self.current_buffer {
-            let amount_read = x.read(buf)?;
-            if amount_read > 0 {
-                return Ok(amount_read);
-            }
+        let amount_read = self.current_buffer.read(buf)?;
+        if amount_read > 0 {
+            return Ok(amount_read);
         }
 
         self.read_slow(buf)
     }
 }
+
 impl MessageReceiver {
+    /// slow path for reads, try to get a new buffer or
+    /// return zero if at the end of the stream
     #[cold]
     #[inline(never)]
     fn read_slow(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
         while !self.end_of_file {
-            if let Some(x) = &mut self.current_buffer {
-                let amount_read = x.read(buf)?;
-                if amount_read > 0 {
-                    return Ok(amount_read);
-                }
+            let amount_read = self.current_buffer.read(buf)?;
+            if amount_read > 0 {
+                return Ok(amount_read);
             }
 
             match self.receiver.recv() {
@@ -1522,7 +1534,7 @@ impl MessageReceiver {
                             tid, self.thread_id,
                             "incoming thread must be equal to processing thread"
                         );
-                        self.current_buffer = Some(Cursor::new(block));
+                        self.current_buffer = Cursor::new(block);
                     }
                 },
                 Err(e) => {

--- a/src/structs/lepton_format.rs
+++ b/src/structs/lepton_format.rs
@@ -400,8 +400,7 @@ fn run_lepton_decoder_threads<R: Read + Seek, P: Send>(
                     let rx = rx_channels[thread_id - start].take().context(here!())?;
                     let mut reader = MessageReceiver {
                         thread_id: thread_id as u8,
-                        current_buffer: Vec::new(),
-                        offset_read: 0,
+                        current_buffer: Cursor::new(Vec::new()),
                         receiver: rx,
                         end_of_file: false,
                     };
@@ -1493,10 +1492,7 @@ struct MessageReceiver {
 
     /// what we are reading. When this returns zero, we try to
     /// refill the buffer if we haven't reached the end of the stream
-    current_buffer: Vec<u8>,
-
-    /// offset in buffer we are reading from
-    offset_read: usize,
+    current_buffer: Cursor<Vec<u8>>,
 
     /// once we get told we are at the end of the stream, we just
     /// always return 0 bytes
@@ -1507,17 +1503,9 @@ impl Read for MessageReceiver {
     /// fast path for reads. If we get zero bytes, take the slow path
     #[inline(always)]
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        // opimizer removes this, but for safety's sake
-        if buf.len() == 0 {
-            return Ok(0);
-        }
-
-        // read only one byte since thats what the reader only ever asks for
-        // this is legal behavior according to the contract
-        if self.offset_read < self.current_buffer.len() {
-            buf[0] = self.current_buffer[self.offset_read];
-            self.offset_read += 1;
-            return Ok(1);
+        let amount_read = self.current_buffer.read(buf)?;
+        if amount_read > 0 {
+            return Ok(amount_read);
         }
 
         self.read_slow(buf)
@@ -1530,14 +1518,10 @@ impl MessageReceiver {
     #[cold]
     #[inline(never)]
     fn read_slow(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if buf.len() == 0 {
-            return Ok(0);
-        }
         while !self.end_of_file {
-            if self.offset_read < self.current_buffer.len() {
-                buf[0] = self.current_buffer[self.offset_read];
-                self.offset_read += 1;
-                return Ok(1);
+            let amount_read = self.current_buffer.read(buf)?;
+            if amount_read > 0 {
+                return Ok(amount_read);
             }
 
             match self.receiver.recv() {
@@ -1550,8 +1534,7 @@ impl MessageReceiver {
                             tid, self.thread_id,
                             "incoming thread must be equal to processing thread"
                         );
-                        self.current_buffer = block;
-                        self.offset_read = 0;
+                        self.current_buffer = Cursor::new(block);
                     }
                 },
                 Err(e) => {

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -201,7 +201,7 @@ impl<R: Read> VPXBoolReader<R> {
         while shift >= 0 {
             // BufReader is already pretty efficient handling small reads, so optimization doesn't help that much
             let mut v = [0u8; 1];
-            let bytes_read = self.upstream_reader.read(&mut v)?;
+            let bytes_read = self.upstream_reader.read(&mut v[..])?;
             if bytes_read == 0 {
                 break;
             }

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -55,7 +55,7 @@ impl<R: Read> VPXBoolReader<R> {
             hash: SimpleHash::new(),
         };
 
-        r.vpx_reader_fill()?;
+        Self::vpx_reader_fill(&mut r.value, &mut r.count, &mut r.upstream_reader)?;
 
         let mut dummy_branch = Branch::new();
         r.get(&mut dummy_branch, ModelComponent::Dummy)?; // marker bit
@@ -134,14 +134,15 @@ impl<R: Read> VPXBoolReader<R> {
 
     #[inline(always)]
     pub fn get(&mut self, branch: &mut Branch, _cmp: ModelComponent) -> Result<bool> {
-        if self.count < 0 {
-            self.vpx_reader_fill()?;
+        let mut tmp_value = self.value;
+        let mut tmp_range = self.range;
+        let mut tmp_count = self.count;
+
+        if tmp_count < 0 {
+            Self::vpx_reader_fill(&mut tmp_value, &mut tmp_count, &mut self.upstream_reader)?;
         }
 
         let probability = branch.get_probability() as u32;
-
-        let mut tmp_range = self.range;
-        let mut tmp_value = self.value;
 
         let split = 1 + (((tmp_range - 1) * probability) >> BITS_IN_BYTE);
         let big_split = (split as u64) << BITS_IN_LONG_MINUS_LAST_BYTE;
@@ -153,18 +154,21 @@ impl<R: Read> VPXBoolReader<R> {
             tmp_range -= split;
             tmp_value -= big_split;
 
-            shift = (tmp_range as u8).leading_zeros() as i32;
+            // so optimizer understands that 0 should never happen and avoids unnecessary jump
+            assert!(tmp_range > 0);
+
+            shift = tmp_range.leading_zeros() as i32 - 24;
         } else {
             branch.record_and_update_false_obs();
             tmp_range = split;
 
-            // optimizer understands that split > 0, so it can optimize this
-            shift = (split as u8).leading_zeros() as i32;
+            // optimizer understands that split > 0
+            shift = split.leading_zeros() as i32 - 24;
         }
 
         self.value = tmp_value << shift;
-        self.count -= shift;
         self.range = tmp_range << shift;
+        self.count = tmp_count - shift;
 
         #[cfg(feature = "compression_stats")]
         {
@@ -193,26 +197,27 @@ impl<R: Read> VPXBoolReader<R> {
         return Ok(bit);
     }
 
-    fn vpx_reader_fill(&mut self) -> Result<()> {
-        let mut tmp_value = self.value;
-        let mut tmp_count = self.count;
-        let mut shift = BITS_IN_LONG_MINUS_LAST_BYTE - (tmp_count + BITS_IN_BYTE);
+    #[cold]
+    #[inline(always)]
+    fn vpx_reader_fill(
+        tmp_value: &mut u64,
+        tmp_count: &mut i32,
+        upstream_reader: &mut R,
+    ) -> Result<()> {
+        let mut shift = BITS_IN_LONG_MINUS_LAST_BYTE - (*tmp_count + BITS_IN_BYTE);
 
         while shift >= 0 {
             // BufReader is already pretty efficient handling small reads, so optimization doesn't help that much
             let mut v = [0u8; 1];
-            let bytes_read = self.upstream_reader.read(&mut v)?;
+            let bytes_read = upstream_reader.read(&mut v)?;
             if bytes_read == 0 {
                 break;
             }
 
-            tmp_value |= (v[0] as u64) << shift;
+            *tmp_value |= (v[0] as u64) << shift;
             shift -= BITS_IN_BYTE;
-            tmp_count += BITS_IN_BYTE;
+            *tmp_count += BITS_IN_BYTE;
         }
-
-        self.value = tmp_value;
-        self.count = tmp_count;
 
         return Ok(());
     }

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -201,7 +201,7 @@ impl<R: Read> VPXBoolReader<R> {
         while shift >= 0 {
             // BufReader is already pretty efficient handling small reads, so optimization doesn't help that much
             let mut v = [0u8; 1];
-            let bytes_read = self.upstream_reader.read(&mut v[..])?;
+            let bytes_read = self.upstream_reader.read(&mut v)?;
             if bytes_read == 0 {
                 break;
             }


### PR DESCRIPTION
Instead of inventing our own cursor, use the builtin one