### PR TITLE
Copy coefficient blocks locally to process them in order to dramatically improve cache usage

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -20,7 +20,6 @@ pub enum JPegType {
 
 pub const COLOR_CHANNEL_NUM_BLOCK_TYPES: usize = 3;
 
-pub const ALIGNED_BLOCK_INDEX_AC_7X7_INDEX: usize = 0;
 pub const ALIGNED_BLOCK_INDEX_DC_INDEX: usize = 49;
 
 pub const ZIGZAG_TO_ALIGNED: [u8; 64] = [

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,7 +16,7 @@ pub(crate) use here;
 
 #[inline(always)]
 pub const fn u16_bit_length(v: u16) -> u8 {
-    return (32 - (v as u32).leading_zeros()) as u8;
+    return 16 - v.leading_zeros() as u8;
 }
 
 #[inline(always)]

--- a/src/structs/block_based_image.rs
+++ b/src/structs/block_based_image.rs
@@ -161,6 +161,15 @@ impl BlockBasedImage {
         }
     }
 
+    #[inline(always)]
+    pub fn append_block(&mut self, block: AlignedBlock) {
+        assert!(
+            self.image.len() < self.image.capacity(),
+            "capacity should be set correctly"
+        );
+        self.image.push(block);
+    }
+
     pub fn get_block_mut(&mut self, dpos: i32) -> &mut AlignedBlock {
         self.fill_up_to_dpos(dpos);
         return &mut self.image[(dpos - self.dpos_offset) as usize];
@@ -169,9 +178,12 @@ impl BlockBasedImage {
 
 /// block of 64 coefficients in the aligned order, which is similar to zigzag except that the 7x7 lower right square comes first,
 /// followed by the DC, followed by the edges
+#[repr(C, align(32))]
 pub struct AlignedBlock {
     raw_data: [i16; 64],
 }
+
+pub static EMPTY_BLOCK: AlignedBlock = AlignedBlock { raw_data: [0; 64] };
 
 impl Default for AlignedBlock {
     fn default() -> Self {
@@ -192,10 +204,14 @@ impl AlignedBlock {
         block_data[usize::from(crate::consts::ZIGZAG_TO_ALIGNED[usize::from(index)])] = value;
     }
 
+    // used for debugging
+    #[allow(dead_code)]
     pub fn get_block(&self) -> &[i16; 64] {
         return &self.raw_data;
     }
 
+    // used for debugging
+    #[allow(dead_code)]
     pub fn get_block_mut(&mut self) -> &mut [i16; 64] {
         return &mut self.raw_data;
     }

--- a/src/structs/block_context.rs
+++ b/src/structs/block_context.rs
@@ -4,8 +4,9 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
-use super::block_based_image::{AlignedBlock, BlockBasedImage};
+use super::block_based_image::{AlignedBlock, BlockBasedImage, EMPTY_BLOCK};
 use super::neighbor_summary::NeighborSummary;
+use super::probability_tables::ProbabilityTables;
 
 pub struct BlockContext {
     block_width: i32,
@@ -71,19 +72,28 @@ impl BlockContext {
         return retval;
     }
 
-    pub fn left<'a>(&self, image_data: &'a BlockBasedImage) -> &'a AlignedBlock {
-        let retval = image_data.get_block(self.cur_block_index - 1);
-        return retval;
-    }
-
-    pub fn above<'a>(&self, image_data: &'a BlockBasedImage) -> &'a AlignedBlock {
-        let retval = image_data.get_block(self.above_block_index);
-        return retval;
-    }
-
-    pub fn above_left<'a>(&self, image_data: &'a BlockBasedImage) -> &'a AlignedBlock {
-        let retval = image_data.get_block(self.above_block_index - 1);
-        return retval;
+    pub fn get_neighbors<'a, const ALL_PRESENT: bool>(
+        &self,
+        image_data: &'a BlockBasedImage,
+        pt: &ProbabilityTables,
+    ) -> (&'a AlignedBlock, &'a AlignedBlock, &'a AlignedBlock) {
+        (
+            if ALL_PRESENT {
+                image_data.get_block(self.above_block_index - 1)
+            } else {
+                &EMPTY_BLOCK
+            },
+            if ALL_PRESENT || pt.is_above_present() {
+                image_data.get_block(self.above_block_index)
+            } else {
+                &EMPTY_BLOCK
+            },
+            if ALL_PRESENT || pt.is_left_present() {
+                image_data.get_block(self.cur_block_index - 1)
+            } else {
+                &EMPTY_BLOCK
+            },
+        )
     }
 
     pub fn non_zeros_here(&self, num_non_zeros: &[NeighborSummary]) -> u8 {

--- a/src/structs/block_context.rs
+++ b/src/structs/block_context.rs
@@ -71,11 +71,6 @@ impl BlockContext {
         return retval;
     }
 
-    pub fn here_mut<'a>(&self, image_data: &'a mut BlockBasedImage) -> &'a mut AlignedBlock {
-        let retval = image_data.get_block_mut(self.cur_block_index);
-        return retval;
-    }
-
     pub fn left<'a>(&self, image_data: &'a BlockBasedImage) -> &'a AlignedBlock {
         let retval = image_data.get_block(self.cur_block_index - 1);
         return retval;

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -11,13 +11,12 @@ use default_boxed::DefaultBoxed;
 use std::cmp;
 use std::io::Read;
 
-use crate::consts::{
-    ALIGNED_BLOCK_INDEX_AC_7X7_INDEX, LOG_TABLE_256, RASTER_TO_ALIGNED, UNZIGZAG_49,
-};
+use crate::consts::{LOG_TABLE_256, RASTER_TO_ALIGNED, UNZIGZAG_49};
 use crate::helpers::{err_exit_code, here, u16_bit_length};
 use crate::lepton_error::ExitCode;
 
 use crate::metrics::Metrics;
+use crate::structs::block_based_image::AlignedBlock;
 use crate::structs::{
     block_based_image::BlockBasedImage, block_context::BlockContext, model::Model,
     model::ModelPerColor, neighbor_summary::NeighborSummary, probability_tables::ProbabilityTables,
@@ -304,6 +303,8 @@ fn parse_token<R: Read, const ALL_PRESENT: bool>(
         [0; 64]
     };
 
+    let mut output = AlignedBlock::default();
+
     let mut eob_x: u8 = 0;
     let mut eob_y: u8 = 0;
     let mut num_non_zeros_left_7x7: u8 = num_non_zeros_7x7;
@@ -311,7 +312,6 @@ fn parse_token<R: Read, const ALL_PRESENT: bool>(
     let best_priors =
         pt.calc_coefficient_context_7x7_aavg_block::<ALL_PRESENT>(&left, &above, &above_left);
 
-    let block = context.here_mut(image_data).get_block_mut();
     for zz in 0..49 {
         if num_non_zeros_left_7x7 == 0 {
             break;
@@ -343,16 +343,15 @@ fn parse_token<R: Read, const ALL_PRESENT: bool>(
             num_non_zeros_left_7x7 -= 1;
         }
 
-        block[zz as usize + ALIGNED_BLOCK_INDEX_AC_7X7_INDEX] = coef;
+        output.set_coefficient(zz, coef);
     }
 
     decode_edge::<R, ALL_PRESENT>(
         model_per_color,
         bool_reader,
-        image_data,
-        context,
         &left,
         &above,
+        &mut output,
         qt,
         pt,
         num_non_zeros_7x7,
@@ -360,8 +359,7 @@ fn parse_token<R: Read, const ALL_PRESENT: bool>(
         eob_y,
     )?;
 
-    let predicted_dc = pt.adv_predict_dc_pix::<ALL_PRESENT>(image_data, qt, context, num_non_zeros);
-    let block = context.here_mut(image_data);
+    let predicted_dc = pt.adv_predict_dc_pix::<ALL_PRESENT>(&output, qt, context, num_non_zeros);
 
     let coef = model
         .read_dc(
@@ -372,7 +370,7 @@ fn parse_token<R: Read, const ALL_PRESENT: bool>(
         )
         .context(here!())?;
 
-    block.set_dc(ProbabilityTables::adv_predict_or_unpredict_dc(
+    output.set_dc(ProbabilityTables::adv_predict_or_unpredict_dc(
         coef,
         true,
         predicted_dc.predicted_dc,
@@ -384,14 +382,16 @@ fn parse_token<R: Read, const ALL_PRESENT: bool>(
     here.set_horizontal(
         &predicted_dc.advanced_predict_dc_pixels_sans_dc,
         qt.get_quantization_table(),
-        block.get_dc(),
+        output.get_dc(),
     );
 
     here.set_vertical(
         &predicted_dc.advanced_predict_dc_pixels_sans_dc,
         qt.get_quantization_table(),
-        block.get_dc(),
+        output.get_dc(),
     );
+
+    *context.here_mut(image_data).get_block_mut() = *output.get_block();
 
     Ok(())
 }
@@ -400,10 +400,9 @@ fn parse_token<R: Read, const ALL_PRESENT: bool>(
 fn decode_edge<R: Read, const ALL_PRESENT: bool>(
     model_per_color: &mut ModelPerColor,
     bool_reader: &mut VPXBoolReader<R>,
-    image_data: &mut BlockBasedImage,
-    context: &BlockContext,
     left: &[i16; 64],
     above: &[i16; 64],
+    here_mut: &mut AlignedBlock,
     qt: &QuantizationTables,
     pt: &ProbabilityTables,
     num_non_zeros_7x7: u8,
@@ -413,10 +412,9 @@ fn decode_edge<R: Read, const ALL_PRESENT: bool>(
     decode_one_edge::<R, ALL_PRESENT, true>(
         model_per_color,
         bool_reader,
-        image_data,
-        context,
         left,
         above,
+        here_mut,
         qt,
         pt,
         num_non_zeros_7x7,
@@ -425,10 +423,9 @@ fn decode_edge<R: Read, const ALL_PRESENT: bool>(
     decode_one_edge::<R, ALL_PRESENT, false>(
         model_per_color,
         bool_reader,
-        image_data,
-        context,
         left,
         above,
+        here_mut,
         qt,
         pt,
         num_non_zeros_7x7,
@@ -440,10 +437,9 @@ fn decode_edge<R: Read, const ALL_PRESENT: bool>(
 fn decode_one_edge<R: Read, const ALL_PRESENT: bool, const HORIZONTAL: bool>(
     model_per_color: &mut ModelPerColor,
     bool_reader: &mut VPXBoolReader<R>,
-    image_data: &mut BlockBasedImage,
-    block_context: &BlockContext,
     left: &[i16; 64],
     above: &[i16; 64],
+    here_mut: &mut AlignedBlock,
     qt: &QuantizationTables,
     pt: &ProbabilityTables,
     num_non_zeros_7x7: u8,
@@ -475,8 +471,6 @@ fn decode_one_edge<R: Read, const ALL_PRESENT: bool, const HORIZONTAL: bool>(
     }
 
     let mut coord = delta;
-
-    let here_mut = block_context.here_mut(image_data);
 
     for lane in 0..7 {
         if num_non_zeros_edge == 0 {

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -305,6 +305,22 @@ fn serialize_tokens<W: Write, const ALL_PRESENT: bool>(
 
     let block = context.here(image_data);
 
+    let above = if ALL_PRESENT || pt.is_above_present() {
+        context.above(image_data).get_block().clone()
+    } else {
+        [0; 64]
+    };
+    let left = if ALL_PRESENT || pt.is_left_present() {
+        context.left(image_data).get_block().clone()
+    } else {
+        [0; 64]
+    };
+    let above_left = if ALL_PRESENT {
+        context.above_left(image_data).get_block().clone()
+    } else {
+        [0; 64]
+    };
+
     #[cfg(feature = "detailed_tracing")]
     trace!(
         "block {0}:{1:x}",
@@ -313,7 +329,7 @@ fn serialize_tokens<W: Write, const ALL_PRESENT: bool>(
     );
 
     let best_priors =
-        pt.calc_coefficient_context_7x7_aavg_block::<ALL_PRESENT>(image_data, context);
+        pt.calc_coefficient_context_7x7_aavg_block::<ALL_PRESENT>(&left, &above, &above_left);
 
     for zig49 in 0..49 {
         if num_non_zeros_left_7x7 == 0 {

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -16,8 +16,8 @@ use crate::lepton_error::ExitCode;
 use crate::metrics::Metrics;
 use crate::structs::{
     block_based_image::AlignedBlock, block_based_image::BlockBasedImage,
-    block_based_image::EMPTY_BLOCK, block_context::BlockContext, model::Model,
-    model::ModelPerColor, neighbor_summary::NeighborSummary, probability_tables::ProbabilityTables,
+    block_context::BlockContext, model::Model, model::ModelPerColor,
+    neighbor_summary::NeighborSummary, probability_tables::ProbabilityTables,
     probability_tables_set::ProbabilityTablesSet, quantization_tables::QuantizationTables,
     row_spec::RowSpec, truncate_components::*, vpx_bool_writer::VPXBoolWriter,
 };
@@ -306,21 +306,7 @@ fn serialize_tokens<W: Write, const ALL_PRESENT: bool>(
 
     let block = context.here(image_data);
 
-    let above_left = if ALL_PRESENT {
-        context.above_left(image_data).clone()
-    } else {
-        &EMPTY_BLOCK
-    };
-    let above = if ALL_PRESENT || pt.is_above_present() {
-        context.above(image_data).clone()
-    } else {
-        &EMPTY_BLOCK
-    };
-    let left = if ALL_PRESENT || pt.is_left_present() {
-        context.left(image_data).clone()
-    } else {
-        &EMPTY_BLOCK
-    };
+    let (above_left, above, left) = context.get_neighbors::<ALL_PRESENT>(image_data, pt);
 
     #[cfg(feature = "detailed_tracing")]
     trace!(

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -378,8 +378,7 @@ fn serialize_tokens<W: Write, const ALL_PRESENT: bool>(
     )
     .context(here!())?;
 
-    let predicted_val =
-        pt.adv_predict_dc_pix::<ALL_PRESENT>(image_data, qt, context, &num_non_zeros);
+    let predicted_val = pt.adv_predict_dc_pix::<ALL_PRESENT>(&block, qt, context, &num_non_zeros);
 
     let avg_predicted_dc = ProbabilityTables::adv_predict_or_unpredict_dc(
         block.get_dc(),

--- a/src/structs/probability_tables.rs
+++ b/src/structs/probability_tables.rs
@@ -119,16 +119,13 @@ impl ProbabilityTables {
     #[inline(never)]
     pub fn calc_coefficient_context_7x7_aavg_block<const ALL_PRESENT: bool>(
         &self,
-        image_data: &BlockBasedImage,
-        block_context: &BlockContext,
+        left: &[i16; 64],
+        above: &[i16; 64],
+        above_left: &[i16; 64],
     ) -> [i16; 49] {
         let mut best_prior = [0; 49];
 
         if ALL_PRESENT {
-            let left = block_context.left(image_data).get_block();
-            let above = block_context.above(image_data).get_block();
-            let above_left = block_context.above_left(image_data).get_block();
-
             // compiler does a pretty amazing job with SSE/AVX2 here
             for i in 0..49 {
                 // approximate average of 3 without a divide with double the weight for left/top vs diagonal
@@ -140,12 +137,10 @@ impl ProbabilityTables {
             // handle edge case :) where we are on the top or left edge
 
             if self.left_present {
-                let left = block_context.left(image_data).get_block();
                 for i in 0..49 {
                     best_prior[i] = left[i].abs();
                 }
             } else if self.above_present {
-                let above = block_context.above(image_data).get_block();
                 for i in 0..49 {
                     best_prior[i] = above[i].abs();
                 }

--- a/src/structs/probability_tables.rs
+++ b/src/structs/probability_tables.rs
@@ -13,7 +13,7 @@ use crate::structs::model::*;
 use crate::structs::quantization_tables::*;
 use std::cmp::{max, min};
 
-use super::block_based_image::BlockBasedImage;
+use super::block_based_image::AlignedBlock;
 use super::block_context::BlockContext;
 use super::neighbor_summary::NeighborSummary;
 use super::probability_tables_coefficient_context::ProbabilityTablesCoefficientContext;
@@ -244,7 +244,7 @@ impl ProbabilityTables {
 
     pub fn adv_predict_dc_pix<const ALL_PRESENT: bool>(
         &self,
-        image_data: &BlockBasedImage,
+        here: &AlignedBlock,
         qt: &QuantizationTables,
         block_context: &BlockContext,
         num_non_zeros: &[NeighborSummary],
@@ -257,7 +257,7 @@ impl ProbabilityTables {
 
         let mut avgmed = 0;
 
-        run_idct::<true>(block_context.here(image_data), q, &mut pixels_sans_dc);
+        run_idct::<true>(here, q, &mut pixels_sans_dc);
 
         if ALL_PRESENT || self.left_present || self.above_present {
             let mut min_dc = i16::MAX;


### PR DESCRIPTION
Instead of processing the data inside the image, copy data into a local AlignedBlock and do all the processing there, then copy back into the image data. Also keep a reference to the neighbors so that we don't recalc/copy this information during the various prediction processors.