### PR TITLE
Fix Markdown in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ Some operations of this library are vectorized such as the IDCT using the [Wide]
 
 - [Rust 1.65 or Above](https://www.rust-lang.org/tools/install)
 
-`git clone https://github.com/microsoft/lepton_jpeg_rust
+```
+git clone https://github.com/microsoft/lepton_jpeg_rust
 cd lepton_jpeg_rust
 cargo build
 cargo test
-cargo build --release`
+cargo build --release
+```
 
 #### Running
 


### PR DESCRIPTION
Inline code snippet ignores line breaks, severely harming readability. A fenced code block is more suitable in this scenario.