### PR TITLE
Remove atty dependency with update to rust 1.70

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,7 +277,7 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lepton_jpeg"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [
  "anyhow",
  "byteorder",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,7 +280,6 @@ name = "lepton_jpeg"
 version = "0.3.3"
 dependencies = [
  "anyhow",
- "atty",
  "byteorder",
  "cpu-time",
  "default-boxed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.3.3"
 edition = "2021"
 authors = ["Kristof Roomp <kristofr@microsoft.com>"]
 
-# requires scoped threads
-rust-version = "1.65"
+# requires scoped threads and IsTerminal
+rust-version = "1.70"
 description = "Rust port of the Lepton JPEG compression library"
 readme = "README.md"
 repository = "https://github.com/microsoft/lepton_jpeg_rust"
@@ -34,7 +34,6 @@ wide = "0.7.5"
 log = "0.4.17"
 simple_logger ="4.0.0"
 cpu-time = "1.0.0"
-atty = "0.2.14"
 
 [dev-dependencies]
 rstest = "0.16.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lepton_jpeg"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 authors = ["Kristof Roomp <kristofr@microsoft.com>"]
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ steps:
 - task: ssplat.rust-build-release-tools.rust-installer-task.RustInstaller@1
   displayName: 'Install Rust '
   inputs:
-    rustVersion: 'ms-1.68'
+    rustVersion: 'ms-1.70'
     additionalTargets: 'i686-pc-windows-msvc'
     toolchainFeed: https://onedrive.pkgs.visualstudio.com/b52099a6-3b13-4b08-9270-a07884a10e3d/_packaging/RustTools/nuget/v3/index.json
     cratesIoFeedOverride: sparse+https://onedrive.pkgs.visualstudio.com/b52099a6-3b13-4b08-9270-a07884a10e3d/_packaging/RustCratesIO/Cargo/index/
@@ -25,10 +25,9 @@ steps:
   displayName: 'Build debug'
 
 - script: |
-   cargo test --locked --lib -- -Z unstable-options --report-time  --format junit 1> $(System.DefaultWorkingDirectory)\TEST-rust.xml
-   echo content of xml
-   type $(System.DefaultWorkingDirectory)\TEST-rust.xml
-   echo end
+   cargo install junit-test
+   junit-test
+   copy junit.xml $(System.DefaultWorkingDirectory)\TEST-rust.xml
   displayName: 'Test debug'
 
 - task: PublishTestResults@2

--- a/package/Lepton.Jpeg.Rust.nuspec
+++ b/package/Lepton.Jpeg.Rust.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
   <metadata>
     <id>Lepton.Jpeg.Rust</id>
-    <version>0.3.3</version>
+    <version>0.3.4</version>
     <title>Lepton JPEG Compression Rust version binaries and libraries</title>
     <authors>kristofr</authors>
     <owners>kristofr</owners>

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ use structs::lepton_format::read_jpeg;
 use std::{
     env,
     fs::{File, OpenOptions},
-    io::{BufReader, Cursor, Read, Seek, Write},
+    io::{stdin, stdout, BufReader, Cursor, IsTerminal, Read, Seek, Write},
     time::Duration,
 };
 
@@ -55,7 +55,7 @@ fn main_with_result() -> anyhow::Result<()> {
     let mut enabled_features = EnabledFeatures::default();
 
     // only output the log if we are connected to a console (otherwise if there is redirection we would corrupt the file)
-    if atty::is(atty::Stream::Stdout) {
+    if stdout().is_terminal() {
         SimpleLogger::new().init().unwrap();
     }
 
@@ -153,7 +153,7 @@ fn main_with_result() -> anyhow::Result<()> {
 
     let mut input_data = Vec::new();
     if filenames.len() != 2 {
-        if atty::is(atty::Stream::Stdin) || atty::is(atty::Stream::Stdout) {
+        if stdout().is_terminal() || stdin().is_terminal() {
             return err_exit_code(
                 ExitCode::SyntaxError,
                 "source and destination filename are needed or input needs to be redirected",


### PR DESCRIPTION
There was a security advisory on this component, although it doesn't directly affect this code since we don't use a custom allocator.