### PR TITLE
fix bug where decoding was failing due to 16 bit math in C++ version

### DIFF
--- a/src/enabled_features.rs
+++ b/src/enabled_features.rs
@@ -11,6 +11,9 @@ pub struct EnabledFeatures {
 
     // maximum jpeg height
     pub max_jpeg_height: i32,
+
+    // Sadly C++ version has a bug where it uses 16 bit math in the SIMD path and 32 bit math in the scalar path
+    pub use_16bit_dc_estimate: bool,
 }
 
 impl Default for EnabledFeatures {
@@ -20,18 +23,21 @@ impl Default for EnabledFeatures {
             reject_dqts_with_zeros: true,
             max_jpeg_width: 16386,
             max_jpeg_height: 16386,
+            use_16bit_dc_estimate: false,
         }
     }
 }
 
 impl EnabledFeatures {
     /// parameters that allow everything
+    #[allow(dead_code)]
     pub fn all() -> Self {
         Self {
             progressive: true,
             reject_dqts_with_zeros: true,
             max_jpeg_height: i32::MAX,
             max_jpeg_width: i32::MAX,
+            use_16bit_dc_estimate: false,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,12 @@ fn main_with_result() -> anyhow::Result<()> {
             let _metrics;
 
             (block_image, _metrics) = lh
-                .decode_as_single_image(&mut reader, filelen, num_threads as usize)
+                .decode_as_single_image(
+                    &mut reader,
+                    filelen,
+                    num_threads as usize,
+                    &enabled_features,
+                )
                 .context(here!())?;
 
             loop {

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -10,6 +10,7 @@ use std::cmp;
 use std::io::Write;
 
 use crate::consts::*;
+use crate::enabled_features::EnabledFeatures;
 use crate::helpers::*;
 use crate::lepton_error::ExitCode;
 
@@ -36,6 +37,7 @@ pub fn lepton_encode_row_range<W: Write>(
     max_y: i32,
     is_last_thread: bool,
     full_file_compression: bool,
+    features: &EnabledFeatures,
 ) -> Result<Metrics> {
     let mut model = Model::default_boxed();
     let mut bool_writer = VPXBoolWriter::new(writer)?;
@@ -106,6 +108,7 @@ pub fn lepton_encode_row_range<W: Write>(
                 &mut num_non_zeros[bt][..],
                 block_width,
                 component_size_in_blocks[bt],
+                features,
             )
             .context(here!())?;
         } else if block_width > 1 {
@@ -122,6 +125,7 @@ pub fn lepton_encode_row_range<W: Write>(
                 &mut num_non_zeros[bt][..],
                 block_width,
                 component_size_in_blocks[bt],
+                features,
             )
             .context(here!())?;
         } else {
@@ -139,6 +143,7 @@ pub fn lepton_encode_row_range<W: Write>(
                 &mut num_non_zeros[bt][..],
                 block_width,
                 component_size_in_blocks[bt],
+                features,
             )
             .context(here!())?;
         }
@@ -182,6 +187,7 @@ fn process_row<W: Write>(
     num_non_zeros: &mut [NeighborSummary],
     block_width: i32,
     component_size_in_block: i32,
+    features: &EnabledFeatures,
 ) -> Result<()> {
     if block_width > 0 {
         state
@@ -196,6 +202,7 @@ fn process_row<W: Write>(
             image_data,
             num_non_zeros,
             bool_writer,
+            features,
         )
         .context(here!())?;
         let offset = state.next(true);
@@ -220,6 +227,7 @@ fn process_row<W: Write>(
                 image_data,
                 num_non_zeros,
                 bool_writer,
+                features,
             )
             .context(here!())?;
         } else {
@@ -231,6 +239,7 @@ fn process_row<W: Write>(
                 image_data,
                 num_non_zeros,
                 bool_writer,
+                features,
             )
             .context(here!())?;
         }
@@ -256,6 +265,7 @@ fn process_row<W: Write>(
                 image_data,
                 num_non_zeros,
                 bool_writer,
+                features,
             )
             .context(here!())?;
         } else {
@@ -267,6 +277,7 @@ fn process_row<W: Write>(
                 image_data,
                 num_non_zeros,
                 bool_writer,
+                features,
             )
             .context(here!())?;
         }
@@ -285,6 +296,7 @@ fn serialize_tokens<W: Write, const ALL_PRESENT: bool>(
     image_data: &BlockBasedImage,
     num_non_zeros: &mut [NeighborSummary],
     bool_writer: &mut VPXBoolWriter<W>,
+    features: &EnabledFeatures,
 ) -> Result<()> {
     debug_assert!(ALL_PRESENT == pt.is_all_present());
 
@@ -401,12 +413,14 @@ fn serialize_tokens<W: Write, const ALL_PRESENT: bool>(
         &predicted_val.advanced_predict_dc_pixels_sans_dc,
         qt.get_quantization_table(),
         block.get_dc(),
+        features,
     );
 
     here.set_vertical(
         &predicted_val.advanced_predict_dc_pixels_sans_dc,
         qt.get_quantization_table(),
         block.get_dc(),
+        features,
     );
 
     Ok(())

--- a/src/structs/lepton_format.rs
+++ b/src/structs/lepton_format.rs
@@ -60,7 +60,7 @@ pub fn decode_lepton_wrapper<R: Read + Seek, W: Write>(
         .context(here!())?;
 
     let metrics = lh
-        .recode_jpeg(writer, reader, size, num_threads)
+        .recode_jpeg(writer, reader, size, num_threads, enabled_features)
         .context(here!())?;
 
     return Ok(metrics);
@@ -83,6 +83,7 @@ pub fn encode_lepton_wrapper<R: Read + Seek, W: Write + Seek>(
         writer,
         &lp.thread_handoff[..],
         &image_data[..],
+        enabled_features,
     )
     .context(here!())?;
 
@@ -311,6 +312,7 @@ fn run_lepton_decoder_threads<R: Read + Seek, P: Send>(
     reader: &mut R,
     last_data_position: u64,
     max_threads_to_use: usize,
+    features: &EnabledFeatures,
     process: fn(
         thread_handoff: &ThreadHandoff,
         image_data: Vec<BlockBasedImage>,
@@ -423,6 +425,7 @@ fn run_lepton_decoder_threads<R: Read + Seek, P: Send>(
                             lh.thread_handoff[thread_id].luma_y_end,
                             thread_id == lh.thread_handoff.len() - 1,
                             true,
+                            features,
                         )
                         .context(here!())?,
                     );
@@ -522,6 +525,7 @@ fn run_lepton_encoder_threads<W: Write + Seek>(
     writer: &mut W,
     thread_handoffs: &[ThreadHandoff],
     image_data: &[BlockBasedImage],
+    features: &EnabledFeatures,
 ) -> Result<Metrics> {
     let wall_time = Instant::now();
 
@@ -583,6 +587,7 @@ fn run_lepton_encoder_threads<W: Write + Seek>(
                     thread_handoffs[thread_id].luma_y_end,
                     thread_id == thread_handoffs.len() - 1,
                     true,
+                    features,
                 )
                 .context(here!())?;
 
@@ -745,6 +750,7 @@ impl LeptonHeader {
         reader: &mut R,
         last_data_position: u64,
         num_threads: usize,
+        enabled_features: &EnabledFeatures,
     ) -> Result<Metrics, anyhow::Error> {
         writer.write_all(&SOI)?;
 
@@ -754,11 +760,23 @@ impl LeptonHeader {
             .context(here!())?;
 
         let metrics = if self.jpeg_header.jpeg_type == JPegType::Progressive {
-            self.recode_progressive_jpeg(reader, last_data_position, writer, num_threads)
-                .context(here!())?
+            self.recode_progressive_jpeg(
+                reader,
+                last_data_position,
+                writer,
+                num_threads,
+                enabled_features,
+            )
+            .context(here!())?
         } else {
-            self.recode_baseline_jpeg(reader, last_data_position, writer, num_threads)
-                .context(here!())?
+            self.recode_baseline_jpeg(
+                reader,
+                last_data_position,
+                writer,
+                num_threads,
+                enabled_features,
+            )
+            .context(here!())?
         };
 
         // Blit any trailing header data.
@@ -777,6 +795,7 @@ impl LeptonHeader {
         reader: &mut R,
         last_data_position: u64,
         num_threads: usize,
+        features: &EnabledFeatures,
     ) -> Result<(Vec<BlockBasedImage>, Metrics)> {
         // run the threads first, since we need everything before we can start decoding
         let (metrics, mut results) = run_lepton_decoder_threads(
@@ -784,6 +803,7 @@ impl LeptonHeader {
             reader,
             last_data_position,
             num_threads,
+            features,
             |_thread_handoff, image_data, _lh| {
                 // just return the image data directly to be merged together
                 return Ok(image_data);
@@ -827,10 +847,11 @@ impl LeptonHeader {
         last_data_position: u64,
         writer: &mut W,
         num_threads: usize,
+        enabled_features: &EnabledFeatures,
     ) -> Result<Metrics> {
         // run the threads first, since we need everything before we can start decoding
         let (merged, metrics) = self
-            .decode_as_single_image(reader, last_data_position, num_threads)
+            .decode_as_single_image(reader, last_data_position, num_threads, enabled_features)
             .context(here!())?;
 
         loop {
@@ -840,7 +861,7 @@ impl LeptonHeader {
             // read the next headers (DHT, etc) while mirroring it back to the writer
             let old_pos = self.raw_jpeg_header_read_index;
             let result = self
-                .advance_next_header_segment(&EnabledFeatures::all())
+                .advance_next_header_segment(enabled_features)
                 .context(here!())?;
 
             writer
@@ -866,6 +887,7 @@ impl LeptonHeader {
         last_data_position: u64,
         writer: &mut W,
         num_threads: usize,
+        enabled_features: &EnabledFeatures,
     ) -> Result<Metrics> {
         // step 2: recode image data
         let (metrics, results) = run_lepton_decoder_threads(
@@ -873,6 +895,7 @@ impl LeptonHeader {
             reader,
             last_data_position,
             num_threads,
+            enabled_features,
             |thread_handoff, image_data, lh| {
                 let mut result_buffer = Vec::with_capacity(thread_handoff.segment_size as usize);
                 let mut cursor = Cursor::new(&mut result_buffer);

--- a/src/structs/neighbor_summary.rs
+++ b/src/structs/neighbor_summary.rs
@@ -6,6 +6,8 @@
 
 use std::num::Wrapping;
 
+use crate::enabled_features::EnabledFeatures;
+
 #[derive(Copy, Clone)]
 pub struct NeighborSummary {
     edge_pixels_h: [i16; 8],
@@ -42,23 +44,57 @@ impl NeighborSummary {
         return &self.edge_pixels_h;
     }
 
-    pub fn set_horizontal(&mut self, data: &[i16; 64], qt: &[u16; 64], dc: i16) {
-        for i in 0..8 {
-            let delta = data[i + 56] as i32 - data[i + 48] as i32;
-            self.edge_pixels_h[i] = ((dc as i32 * qt[0] as i32)
-                + data[i + 56] as i32
-                + (128 * X_IDCT_SCALE)
-                + (delta / 2)) as i16;
+    pub fn set_horizontal(
+        &mut self,
+        data: &[i16; 64],
+        qt: &[u16; 64],
+        dc: i16,
+        enabled_features: &EnabledFeatures,
+    ) {
+        if enabled_features.use_16bit_dc_estimate {
+            // Sadly C++ version has a bug where it uses 16 bit math in the SIMD path and 32 bit math in the scalar path
+            for i in 0..8 {
+                let delta = data[i + 56].wrapping_sub(data[i + 48]);
+                self.edge_pixels_h[i] = ((dc as i32 * qt[0] as i32) as i16)
+                    .wrapping_add(data[i + 56])
+                    .wrapping_add(128 * X_IDCT_SCALE as i16)
+                    .wrapping_add(delta / 2);
+            }
+        } else {
+            for i in 0..8 {
+                let delta = data[i + 56] as i32 - data[i + 48] as i32;
+                self.edge_pixels_h[i] = ((dc as i32 * qt[0] as i32)
+                    + data[i + 56] as i32
+                    + (128 * X_IDCT_SCALE)
+                    + (delta / 2)) as i16;
+            }
         }
     }
 
-    pub fn set_vertical(&mut self, data: &[i16; 64], qt: &[u16; 64], dc: i16) {
-        for i in 0..8 {
-            let delta = data[(i * 8) + 7] as i32 - data[(i * 8) + 6] as i32;
-            self.edge_pixels_v[i] = ((dc as i32 * qt[0] as i32)
-                + data[(i * 8) + 7] as i32
-                + (128 * X_IDCT_SCALE)
-                + (delta / 2)) as i16;
+    pub fn set_vertical(
+        &mut self,
+        data: &[i16; 64],
+        qt: &[u16; 64],
+        dc: i16,
+        features: &EnabledFeatures,
+    ) {
+        if features.use_16bit_dc_estimate {
+            // Sadly C++ version has a bug where it uses 16 bit math in the SIMD path and 32 bit math in the scalar path
+            for i in 0..8 {
+                let delta: i16 = data[(i * 8) + 7].wrapping_sub(data[(i * 8) + 6]);
+                self.edge_pixels_v[i] = ((dc as i32 * qt[0] as i32) as i16)
+                    .wrapping_add(data[(i * 8) + 7])
+                    .wrapping_add((128 * X_IDCT_SCALE) as i16)
+                    .wrapping_add(delta / 2);
+            }
+        } else {
+            for i in 0..8 {
+                let delta = data[(i * 8) + 7] as i32 - data[(i * 8) + 6] as i32;
+                self.edge_pixels_v[i] = ((dc as i32 * qt[0] as i32)
+                    + data[(i * 8) + 7] as i32
+                    + (128 * X_IDCT_SCALE)
+                    + (delta / 2)) as i16;
+            }
         }
     }
 


### PR DESCRIPTION
In the C++ implementation of Lepton, there is an inconsistency with the SIMD and scalar codepath where the scalar version uses 32 bit math and the SIMD path uses 16 bit math. This is not normally an issue except for very rare JPEGs that are very noisy with an extremely high frequency domain that cause an overflow in the 16 bit math. This results in the models diverging and decompression failure.

The fix retries decompression if it fails with a compatible implementation of the 16 bit math. Unfortunately we can't tell ahead of time which version of the C++ code was used since the SIMD codepath depends on compiler options even for the same version. 