### PR TITLE
Add `-max-width:n` and `-max-height:n` CLI options

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,19 +23,21 @@ cargo build --release
 
 #### Running
 
-There is an `lepton_jpeg_util.exe` wrapper that is built as part of the project. It can be used to compress/decompress and also to verify the test end-to-end on a given JPEG. If the input file has a `.jpg` extension, it will encode. If the input file has a `.lep` extension, it will decode back to the original`.jpg`. 
+There is an `lepton_jpeg_util.exe` wrapper that is built as part of the project. It can be used to compress/decompress and also to verify the test end-to-end on a given JPEG. If the input file has a `.jpg` extension, it will encode. If the input file has a `.lep` extension, it will decode back to the original`.jpg`.
 
 It supports the following options:
 
 `lepton_jpeg_util.exe [options] <inputfile> [<outputfile>]`
 
-| Option           | Description                                                  |
-| ---------------- | ------------------------------------------------------------ |
-| `-threads:n`     | Runs with a maximum of n threads. For encoding, this limits the amount of parallelism that can be gotten out of the decoder. |
-| `-dump`          | Dumps the contents of a JPG or LEP file, with the -all option, it will also dump the cooefficient image blocks |
-| `-noprogressive` | Will cause an error if we encounter a progressive file rather than trying to encode it |
-| `-verify`        | Reads, encodes and unencodes verifying that there is an exact match. No output file is specified. |
-| `-iter:n`        | Runs N iterations of the operation. Useful when we are running inside a profiler. |
+| Option                  | Description                                                  |
+| ----------------------- | ------------------------------------------------------------ |
+| `-threads:n`            | Runs with a maximum of n threads. For encoding, this limits the amount of parallelism that can be gotten out of the decoder. |
+| `-dump`                 | Dumps the contents of a JPG or LEP file, with the `-all` option, it will also dump the cooefficient image blocks. |
+| `-noprogressive`        | Will cause an error if we encounter a progressive file rather than trying to encode it. |
+| `-acceptdqtswithzeros`  | Accept images with DQTs with zeros (may cause divide-by-zero). |
+| `-iter:n`               | Runs N iterations of the operation. Useful when we are running inside a profiler. |
+| `-max-width:n`          | Limit the maximum image width to n pixels, instead of the default 16386. Fails with an error if limit is exceeded. |
+| `-max-height:n`         | Limit the maximum image height to n pixels, instead of the default 16386. Fails with an error il limit is exceeded. |
 
 ## Contributing
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,10 @@ fn main_with_result() -> anyhow::Result<()> {
                 num_threads = x;
             } else if let Some(x) = parse_numeric_parameter(args[i].as_str(), "-iter:") {
                 iterations = x;
+            } else if let Some(x) = parse_numeric_parameter(args[i].as_str(), "-max-width:") {
+                enabled_features.max_jpeg_width = x;
+            } else if let Some(x) = parse_numeric_parameter(args[i].as_str(), "-max-height:") {
+                enabled_features.max_jpeg_height = x;
             } else if args[i] == "-dump" {
                 dump = true;
             } else if args[i] == "-all" {

--- a/src/structs/jpeg_header.rs
+++ b/src/structs/jpeg_header.rs
@@ -531,7 +531,7 @@ impl JPegHeader {
 
                 if self.img_height > enabled_features.max_jpeg_height || self.img_width > enabled_features.max_jpeg_width
                 {
-                    return err_exit_code(ExitCode::UnsupportedJpeg, "image dimensions larger than 16386");
+                    return err_exit_code(ExitCode::UnsupportedJpeg, format!("image dimensions larger than {0}x{1}", enabled_features.max_jpeg_width, enabled_features.max_jpeg_height).as_str());
                 }
 
                 self.cmpc = usize::from(segment[hpos + 5]);


### PR DESCRIPTION
Sorry, for the premature form submit.

This adds `-max-width:n` and `-max-height:n` CLI options to `lepton_jpeg_util`, since the defaults seem pretty arbitrary?