### PR TITLE
optimize branch logic

### DIFF
--- a/src/structs/branch.rs
+++ b/src/structs/branch.rs
@@ -164,15 +164,7 @@ fn test_all_probabilities() {
         for _k in 0..10 {
             old_f.record_obs_and_update(false);
             new_f.record_and_update_false_obs();
-            if old_f.probability == 0 {
-                // there is a change of behavior here compared to the C++ version,
-                // but because of the way split is calculated it doesn't result in an
-                // overall change in the way that encoding is done, but it does simplify
-                // one of the corner cases.
-                assert_eq!(old_f.probability, 1);
-            } else {
-                assert_eq!(old_f.probability, new_f.get_probability());
-            }
+            assert_eq!(old_f.probability, new_f.get_probability());
         }
 
         let mut old_t = OriginalImplForTest {
@@ -185,14 +177,14 @@ fn test_all_probabilities() {
             old_t.record_obs_and_update(true);
             new_t.record_and_update_true_obs();
 
-            if old_f.probability == 0 {
+            if old_t.probability == 0 {
                 // there is a change of behavior here compared to the C++ version,
                 // but because of the way split is calculated it doesn't result in an
                 // overall change in the way that encoding is done, but it does simplify
                 // one of the corner cases.
-                assert_eq!(old_f.probability, 1);
+                assert_eq!(new_t.get_probability(), 1);
             } else {
-                assert_eq!(old_f.probability, new_f.get_probability());
+                assert_eq!(old_t.probability, new_t.get_probability());
             }
         }
     }


### PR DESCRIPTION
based on feedback from #49 from @Melirius

>Analysing the code I got to conclusion that corner case even if present in the initial code of Lepton, does not affect its behaviour. Citing https://github.com/microsoft/lepton_jpeg_rust/blob/main/src/structs/branch.rs
>
>The only corner case is that in the case of 255 true and 1
 false, the C++ version decides to set the probability to 0 for the next
 true value, which is different than the formula ((a << 8) / ( a + b )).
The formula produces 1 here, and this does not affect neither https://github.com/microsoft/lepton_jpeg_rust/blob/main/src/structs/vpx_bool_reader.rs#L147 nor https://github.com/microsoft/lepton_jpeg_rust/blob/main/src/structs/vpx_bool_writer.rs#L159 as from [VP8 spec](https://datatracker.ietf.org/doc/html/rfc6386#section-7.2) range of tmp_range is [128,255], so that both bugged and formula version give split = 1.
