### PR TITLE
use rotation to remove branching in inner loop

### DIFF
--- a/src/structs/branch.rs
+++ b/src/structs/branch.rs
@@ -75,7 +75,7 @@ impl Branch {
 
     #[inline(always)]
     pub fn record_and_update_bit(&mut self, bit: bool) {
-        // rotation is use to update either the true or false counter
+        // rotation is used to update either the true or false counter
         // this allows the same code to be used without branching,
         // which makes the CPU about 20% happier
         let orig = self.counts.rotate_left(bit as u32 * 8);
@@ -84,7 +84,7 @@ impl Branch {
             // normalize, except in special case where we have 0xff or more same bits in a row
             // in which case we want to bias the probability to get better compression
             //
-            // Branch prediction realizes that this section is not often executed
+            // CPU branch prediction soon realizes that this section is not often executed
             // and will optimize for the common case where the counts are not 0xff.
             let mask = if orig == 0xff01 { 0xff00 } else { 0x8100 };
             sum = ((1 + (sum & 0xff)) >> 1) | mask;

--- a/src/structs/branch.rs
+++ b/src/structs/branch.rs
@@ -77,7 +77,13 @@ impl Branch {
     pub fn record_and_update_bit(&mut self, bit: bool) {
         // rotation is used to update either the true or false counter
         // this allows the same code to be used without branching,
-        // which makes the CPU about 20% happier
+        // which makes the CPU about 20% happier.
+        //
+        // Since the bits are randomly 1/0, the CPU branch predictor does
+        // a terrible job and ends up wasting a lot of time. Normally
+        // branches are a better idea if the branch very predictable vs
+        // this case where it is better to always pay the price of the
+        // extra rotation to avoid the branch.
         let orig = self.counts.rotate_left(bit as u32 * 8);
         let (mut sum, o) = orig.overflowing_add(0x100);
         if o {

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -149,8 +149,10 @@ impl<R: Read> VPXBoolReader<R> {
         let bit = tmp_value >= big_split;
 
         let shift;
+
+        branch.record_and_update_bit(bit);
+
         if bit {
-            branch.record_and_update_true_obs();
             tmp_range -= split;
             tmp_value -= big_split;
 
@@ -166,7 +168,6 @@ impl<R: Read> VPXBoolReader<R> {
 
             shift = tmp_range.leading_zeros() as i32 - 24;
         } else {
-            branch.record_and_update_false_obs();
             tmp_range = split;
 
             // optimizer understands that split > 0

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -161,14 +161,14 @@ impl<W: Write> VPXBoolWriter<W> {
         let mut tmp_low_value = self.low_value;
 
         let mut shift;
+        branch.record_and_update_bit(value);
+
         if value {
-            branch.record_and_update_true_obs();
             tmp_low_value += split;
             tmp_range -= split;
 
             shift = (tmp_range as u8).leading_zeros() as i32;
         } else {
-            branch.record_and_update_false_obs();
             tmp_range = split;
 
             // optimizer understands that split > 0, so it can optimize this


### PR DESCRIPTION
Felt inspired for some reason. Who knew that there was another 20% of optimization left in the inner loop @danielrh

This change removes 2 branches from the inner loop:
- instead of having two paths for updating the counter (one for the high byte and one for the low byte), use bit rotation at the beginning and end (depending on if it was a 1 or 0) to use the same code in both cases
- use a different mask for special casing, which allows the optimizer to use a conditional move instead of a jump instruction 