### PR TITLE
add high and low priority flags to lepton utility for more reliable benchmarking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.81"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
 dependencies = [
  "backtrace",
 ]
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+
+[[package]]
 name = "bytemuck"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -70,9 +76,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.92"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
 
 [[package]]
 name = "cfg-if"
@@ -165,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
 
 [[package]]
 name = "flate2"
@@ -235,7 +241,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -324,6 +330,7 @@ dependencies = [
  "rayon",
  "rstest",
  "simple_logger",
+ "thread-priority",
  "wide",
 ]
 
@@ -404,18 +411,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -530,7 +537,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.58",
+ "syn 2.0.60",
  "unicode-ident",
 ]
 
@@ -550,6 +557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+
+[[package]]
 name = "safe_arch"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,22 +579,22 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -618,9 +631,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -628,10 +641,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.34"
+name = "thread-priority"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "a617e9eeeb20448b01a8e2427fb80dfbc9c49d79a1de3b11f25731edbf547e3c"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -652,9 +679,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",
@@ -674,9 +701,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wide"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89beec544f246e679fc25490e3f8e08003bc4bf612068f325120dad4cea02c1c"
+checksum = "81a1851a719f11d1d2fea40e15c72f6c00de8c142d7ac47c1441cc7e4d0d5bc6"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ wide = "0.7"
 log = "0.4"
 simple_logger ="4.0"
 rayon = "1.10"
+thread-priority = "0.16"
 
 [target.'cfg(windows)'.dependencies]
 cpu-time = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,10 @@ wide = "0.7"
 log = "0.4"
 simple_logger ="4.0"
 rayon = "1.10"
-thread-priority = "0.16"
 
 [target.'cfg(windows)'.dependencies]
 cpu-time = "1.0"
+thread-priority = "0.16"
 
 [dev-dependencies]
 rstest = "0.18"

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ use lepton_jpeg::metrics::CpuTimeMeasure;
 use log::info;
 use simple_logger::SimpleLogger;
 use structs::lepton_format::read_jpeg;
+use thread_priority::{set_current_thread_priority, ThreadPriority};
 
 use std::{
     env,
@@ -73,6 +74,20 @@ fn main_with_result() -> anyhow::Result<()> {
                 dump = true;
             } else if args[i] == "-all" {
                 all = true;
+            } else if args[i] == "-high" {
+                let b = rayon::ThreadPoolBuilder::new();
+                b.start_handler(|_| {
+                    set_current_thread_priority(ThreadPriority::Max).unwrap();
+                })
+                .build_global()
+                .unwrap();
+            } else if args[i] == "-low" {
+                let b = rayon::ThreadPoolBuilder::new();
+                b.start_handler(|_| {
+                    set_current_thread_priority(ThreadPriority::Min).unwrap();
+                })
+                .build_global()
+                .unwrap();
             } else if args[i] == "-overwrite" {
                 overwrite = true;
             } else if args[i] == "-noprogressive" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,35 +79,35 @@ fn main_with_result() -> anyhow::Result<()> {
                 // any threadpool threads are set to the high priority
 
                 #[cfg(target_os = "windows")]
-                let priority = ThreadPriority::Os(WinAPIThreadPriority::TimeCritical.into());
-                #[cfg(not(target_os = "windows"))]
-                let priority = ThreadPriority::Max;
+                {
+                    let priority = ThreadPriority::Os(WinAPIThreadPriority::TimeCritical.into());
 
-                set_current_thread_priority(priority).unwrap();
-
-                let b = rayon::ThreadPoolBuilder::new();
-                b.start_handler(move |_| {
                     set_current_thread_priority(priority).unwrap();
-                })
-                .build_global()
-                .unwrap();
+
+                    let b = rayon::ThreadPoolBuilder::new();
+                    b.start_handler(move |_| {
+                        set_current_thread_priority(priority).unwrap();
+                    })
+                    .build_global()
+                    .unwrap();
+                }
             } else if args[i] == "-lowpriority" {
                 // used to force to run on e-cores, make sure this and
                 // any threadpool threads are set to the high priority
 
                 #[cfg(target_os = "windows")]
-                let priority = ThreadPriority::Os(WinAPIThreadPriority::Idle.into());
-                #[cfg(not(target_os = "windows"))]
-                let priority = ThreadPriority::Min;
+                {
+                    let priority = ThreadPriority::Os(WinAPIThreadPriority::Idle.into());
 
-                set_current_thread_priority(priority).unwrap();
-
-                let b = rayon::ThreadPoolBuilder::new();
-                b.start_handler(move |_| {
                     set_current_thread_priority(priority).unwrap();
-                })
-                .build_global()
-                .unwrap();
+
+                    let b = rayon::ThreadPoolBuilder::new();
+                    b.start_handler(move |_| {
+                        set_current_thread_priority(priority).unwrap();
+                    })
+                    .build_global()
+                    .unwrap();
+                }
             } else if args[i] == "-overwrite" {
                 overwrite = true;
             } else if args[i] == "-noprogressive" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,20 +74,30 @@ fn main_with_result() -> anyhow::Result<()> {
                 dump = true;
             } else if args[i] == "-all" {
                 all = true;
-            } else if args[i] == "-high" {
+            } else if args[i] == "-highpriority" {
+                // used to force to run on p-cores, make sure this and
+                // any threadpool threads are set to the high priority
+
                 let b = rayon::ThreadPoolBuilder::new();
                 b.start_handler(|_| {
                     set_current_thread_priority(ThreadPriority::Max).unwrap();
                 })
                 .build_global()
                 .unwrap();
-            } else if args[i] == "-low" {
+
+                set_current_thread_priority(ThreadPriority::Max).unwrap()
+            } else if args[i] == "-lowpriority" {
+                // used to force to run on e-cores, make sure this and
+                // any threadpool threads are set to the high priority
+
                 let b = rayon::ThreadPoolBuilder::new();
                 b.start_handler(|_| {
                     set_current_thread_priority(ThreadPriority::Min).unwrap();
                 })
                 .build_global()
                 .unwrap();
+
+                set_current_thread_priority(ThreadPriority::Min).unwrap()
             } else if args[i] == "-overwrite" {
                 overwrite = true;
             } else if args[i] == "-noprogressive" {


### PR DESCRIPTION
The later gen Intel CPUs can run threads on p-cores or e-cores, which have very different performance characteristics. Windows uses the thread priority to decide which core to run on, so if we set a high priority it will run on the p-core and if we set a low priority it will run on the e-core.

This allows us to run perf benchmarks with less variance on CPU time to make it easier to estimate performance differences.