### PR TITLE
Make 7x7 non_zero count and zig49 a single array

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -65,6 +65,16 @@ pub const NON_ZERO_TO_BIN_7X7: [u8; 50] = [
     8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
 ];
 
+pub const NON_ZERO_TO_BIN_7X7_X49: [u16; 50] = {
+    let mut arr = [0; 50];
+    let mut i = 0;
+    while i < 50 {
+        arr[i] = NON_ZERO_TO_BIN_7X7[i] as u16 * 49;
+        i += 1;
+    }
+    arr
+};
+
 //pub const MAX_FILE_SIZE_BYTES : i32 = 128 * 1024 * 1024;
 pub const MAX_THREADS: usize = 8;
 

--- a/src/structs/probability_tables.rs
+++ b/src/structs/probability_tables.rs
@@ -86,8 +86,8 @@ impl ProbabilityTables {
         return NON_ZERO_TO_BIN[num_non_zeros as usize];
     }
 
-    pub fn num_non_zeros_to_bin_7x7(num_non_zeros: u8) -> u8 {
-        return NON_ZERO_TO_BIN_7X7[num_non_zeros as usize];
+    pub fn num_non_zeros_to_bin_7x7_x49(num_non_zeros: u8) -> u16 {
+        return NON_ZERO_TO_BIN_7X7_X49[num_non_zeros as usize];
     }
 
     pub fn calc_non_zero_counts_context_7x7<const ALL_PRESENT: bool>(
@@ -165,7 +165,6 @@ impl ProbabilityTables {
         here: &AlignedBlock,
         above: &AlignedBlock,
         left: &AlignedBlock,
-        num_non_zeros_x: u8,
     ) -> ProbabilityTablesCoefficientContext {
         let mut compute_lak_coeffs_x: [i32; 8] = [0; 8];
         let mut compute_lak_coeffs_a: [i32; 8] = [0; 8];
@@ -220,7 +219,6 @@ impl ProbabilityTables {
         } else {
             return ProbabilityTablesCoefficientContext {
                 best_prior: 0,
-                num_non_zeros_bin: num_non_zeros_x - 1,
                 best_prior_bit_len: 0,
             };
         }
@@ -239,7 +237,6 @@ impl ProbabilityTables {
 
         return ProbabilityTablesCoefficientContext {
             best_prior,
-            num_non_zeros_bin: num_non_zeros_x - 1,
             best_prior_bit_len: u32_bit_length(cmp::min(best_prior.unsigned_abs(), 1023)),
         };
     }

--- a/src/structs/probability_tables_coefficient_context.rs
+++ b/src/structs/probability_tables_coefficient_context.rs
@@ -6,7 +6,6 @@
 
 pub struct ProbabilityTablesCoefficientContext {
     pub best_prior: i32, // lakhani or aavrg depending on coefficient number
-    pub num_non_zeros_bin: u8,
     pub best_prior_bit_len: u8,
 }
 
@@ -20,7 +19,6 @@ impl ProbabilityTablesCoefficientContext {
     pub fn new() -> Self {
         return ProbabilityTablesCoefficientContext {
             best_prior: 0,
-            num_non_zeros_bin: 0,
             best_prior_bit_len: 0,
         };
     }


### PR DESCRIPTION
- Incrementally advance through array as we update
- Align counts at 256 byte boundary (types are already close to that)
- Split out zero prior_bit_len since this is many times sequentially accessed, it also makes the counts just under 256 bytes (as opposed to 0x106 bytes)
