### PR TITLE
remove warning for dead code that isn't turned on normally

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -64,16 +64,7 @@ pub struct Metrics {
     cpu_time_worker_time: Duration,
 }
 
-pub trait ModelStatsCollector {
-    fn record_compression_stats(
-        &mut self,
-        cmp: ModelComponent,
-        total_bits: i64,
-        total_compressed: i64,
-    );
-}
-
-impl ModelStatsCollector for Metrics {
+impl Metrics {
     #[allow(dead_code)]
     fn record_compression_stats(
         &mut self,
@@ -88,9 +79,7 @@ impl ModelStatsCollector for Metrics {
         e.total_bits += total_bits;
         e.total_compressed += total_compressed;
     }
-}
 
-impl Metrics {
     pub fn record_cpu_worker_time(&mut self, duration: Duration) {
         self.cpu_time_worker_time += duration;
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -74,6 +74,7 @@ pub trait ModelStatsCollector {
 }
 
 impl ModelStatsCollector for Metrics {
+    #[allow(dead_code)]
     fn record_compression_stats(
         &mut self,
         cmp: ModelComponent,

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -26,9 +26,6 @@ use std::io::{Read, Result};
 
 use crate::metrics::{Metrics, ModelComponent};
 
-#[cfg(feature = "compression_stats")]
-use crate::metrics::ModelStatsCollector;
-
 use super::{branch::Branch, simple_hash::SimpleHash};
 
 const BITS_IN_BYTE: i32 = 8;

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -26,9 +26,6 @@ use std::io::{Result, Write};
 
 use crate::metrics::{Metrics, ModelComponent};
 
-#[cfg(feature = "compression_stats")]
-use crate::metrics::ModelStatsCollector;
-
 use super::{branch::Branch, simple_hash::SimpleHash};
 
 pub struct VPXBoolWriter<W> {


### PR DESCRIPTION
Compression stats are not normally enabled (they are behind a feature tag that's just used for benchmarking). Avoid dead code warning by not enabling this if compression stats were not enabled.

Warning started popping up with a new compiler version. For some reason it doesn't like the trait being partially enabled. Removed the trait since it was unused anyway.