### PR TITLE
Simplification of BlockContext

### DIFF
--- a/src/structs/block_based_image.rs
+++ b/src/structs/block_based_image.rs
@@ -110,17 +110,13 @@ impl BlockBasedImage {
         );
     }
 
+    // blocks above the first line are never dereferenced
     pub fn off_y(&self, y: i32) -> BlockContext {
         return BlockContext::new(
             self.block_width * y,
-            if y != 0 {
-                self.block_width * (y - 1)
-            } else {
-                -1
-            },
+            self.block_width * (y - 1),
             if (y & 1) != 0 { self.block_width } else { 0 },
             if (y & 1) != 0 { 0 } else { self.block_width },
-            self,
         );
     }
 

--- a/src/structs/block_context.rs
+++ b/src/structs/block_context.rs
@@ -9,8 +9,6 @@ use super::neighbor_summary::{NeighborSummary, NEIGHBOR_DATA_EMPTY};
 use super::probability_tables::ProbabilityTables;
 
 pub struct BlockContext {
-    block_width: i32,
-
     cur_block_index: i32,
     above_block_index: i32,
 
@@ -32,30 +30,15 @@ impl BlockContext {
         self.cur_block_index
     }
 
-    pub fn next(&mut self, has_more: bool) -> i32 {
+    // as each new line BlockContext is set by `off_y`, no edge cases with dereferencing
+    // out of bounds indices is possilbe, therefore no special treatment is needed
+    pub fn next(&mut self) -> i32 {
         self.cur_block_index += 1;
-
-        let retval = self.cur_block_index;
-
-        if retval < self.block_width {
-            self.above_block_index = self.cur_block_index + self.block_width;
-        } else {
-            self.above_block_index = self.cur_block_index - self.block_width;
-        }
-
+        self.above_block_index += 1;
         self.cur_num_non_zeros_index += 1;
         self.above_num_non_zero_index += 1;
 
-        if !has_more {
-            let cur_row_first = self.cur_num_non_zeros_index < self.above_num_non_zero_index;
-            if cur_row_first {
-                self.above_num_non_zero_index -= self.block_width * 2;
-            } else {
-                self.cur_num_non_zeros_index -= self.block_width * 2;
-            }
-        }
-
-        return retval;
+        self.cur_block_index
     }
 
     pub fn new(
@@ -63,10 +46,8 @@ impl BlockContext {
         above_block_index: i32,
         cur_num_non_zeros_index: i32,
         above_num_non_zero_index: i32,
-        image_data: &BlockBasedImage,
     ) -> Self {
         return BlockContext {
-            block_width: image_data.get_block_width(),
             cur_block_index,
             above_block_index,
             cur_num_non_zeros_index,

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -203,7 +203,7 @@ fn decode_row<R: Read>(
             features,
         )
         .context(here!())?;
-        let offset = block_context.next(true);
+        let offset = block_context.next();
 
         if offset >= component_size_in_blocks {
             return Ok(()); // no sure if this is an error
@@ -237,7 +237,7 @@ fn decode_row<R: Read>(
             .context(here!())?;
         }
 
-        let offset = block_context.next(true);
+        let offset = block_context.next();
 
         if offset >= component_size_in_blocks {
             return Ok(()); // no sure if this is an error
@@ -271,7 +271,7 @@ fn decode_row<R: Read>(
             .context(here!())?;
         }
 
-        block_context.next(false);
+        block_context.next();
     }
     Ok(())
 }

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -203,7 +203,7 @@ fn process_row<W: Write>(
             features,
         )
         .context(here!())?;
-        let offset = state.next(true);
+        let offset = state.next();
 
         if offset >= component_size_in_block {
             return Ok(());
@@ -238,7 +238,7 @@ fn process_row<W: Write>(
             .context(here!())?;
         }
 
-        let offset = state.next(true);
+        let offset = state.next();
 
         if offset >= component_size_in_block {
             return Ok(());
@@ -272,7 +272,7 @@ fn process_row<W: Write>(
             .context(here!())?;
         }
 
-        state.next(false);
+        state.next();
     }
     Ok(())
 }


### PR DESCRIPTION
As each new line of DCT blocks in Lepton processing `BlockContext` is set by `off_y`, no out of bounds accesses are possible and BlockContext can be dumb, with no special treatment for edge cases.