### PR TITLE
Add test cases for handling overflows on dequantization and fix size of count7x7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,6 +327,7 @@ dependencies = [
  "flate2",
  "log",
  "rand",
+ "rand_chacha",
  "rayon",
  "rstest",
  "simple_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ thread-priority = "1.0.0"
 [dev-dependencies]
 rstest = "0.19"
 rand = "0.8"
+rand_chacha = "0.3"
 siphasher = "1"
 
 [[bin]]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -90,6 +90,14 @@ pub fn calc_sign_index(val: i32) -> usize {
     }
 }
 
+#[cfg(test)]
+pub fn get_rand_from_seed(seed: [u8; 32]) -> rand_chacha::ChaCha12Rng {
+    use rand_chacha::rand_core::SeedableRng;
+    use rand_chacha::ChaCha12Rng;
+
+    ChaCha12Rng::from_seed(seed)
+}
+
 /*
 better way to update aritmetic encoding without using special division
 

--- a/src/structs/bit_writer.rs
+++ b/src/structs/bit_writer.rs
@@ -200,15 +200,13 @@ fn roundtrip_bits() {
 /// verify the the bits roundtrip correctly with random bits
 #[test]
 fn roundtrip_randombits() {
-    use rand::rngs::StdRng;
     use rand::Rng;
-    use rand::SeedableRng;
 
     let mut buf = Vec::new();
 
     const ITERATIONS: usize = 10000;
 
-    let mut rng = StdRng::from_seed([0u8; 32]);
+    let mut rng = crate::helpers::get_rand_from_seed([0u8; 32]);
     let mut test_data = Vec::with_capacity(ITERATIONS);
 
     for _ in 0..ITERATIONS {

--- a/src/structs/idct.rs
+++ b/src/structs/idct.rs
@@ -344,11 +344,9 @@ pub fn test_idct_with_simple_block() {
 /// implemenation from the original scalar C++ code
 #[test]
 pub fn test_idct_with_random_blocks() {
-    use rand::rngs::StdRng;
     use rand::Rng;
-    use rand::SeedableRng;
 
-    let mut rng = StdRng::from_seed([0u8; 32]);
+    let mut rng = crate::helpers::get_rand_from_seed([0u8; 32]);
     let mut test_data = AlignedBlock::default();
     let mut test_q = [0u16; 64];
 

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -784,6 +784,18 @@ fn roundtrip_random() {
     let above_left = AlignedBlock::new(arr.map(|_| rng.gen_range(-2047..=2047)));
     let qt = arr.map(|_| rng.gen_range(1u16..=65535));
 
+    // using 32 bit math (test emulating both scalar and vector C++ code)
+    roundtrip_read_write_coefficients(
+        &left,
+        &above,
+        &above_left,
+        &here,
+        qt,
+        0xddae63102f8762ff,
+        &EnabledFeatures::compat_lepton_scalar_read(),
+    );
+
+    // using 16 bit math
     roundtrip_read_write_coefficients(
         &left,
         &above,

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -163,13 +163,13 @@ pub struct ModelPerColor {
 
 #[derive(DefaultBoxed)]
 struct Counts7x7 {
-    exponent_counts: [[Branch; MAX_EXPONENT]; MAX_EXPONENT],
+    exponent_counts: [[Branch; MAX_EXPONENT]; NUMERIC_LENGTH_MAX],
     residual_noise_counts: [Branch; COEF_BITS],
 }
 
 #[derive(DefaultBoxed)]
 struct CountsEdge {
-    // predictors for exponents are max 11 bits wide, not 12
+    // predictors for exponents are max 11 bits wide, not 12 since they are clamped
     exponent_counts: [[Branch; MAX_EXPONENT]; MAX_EXPONENT],
     // size by possible range of `min_threshold - 1`
     // that is from 0 up to `bit_width(max(freq_max)) - RESIDUAL_NOISE_FLOOR - 1`
@@ -251,7 +251,7 @@ impl ModelPerColor {
         );
         assert!(zig49 < 49, "zig49 {0} too high", num_non_zeros_bin);
         assert!(
-            best_prior_bit_len < MAX_EXPONENT,
+            best_prior_bit_len < NUMERIC_LENGTH_MAX,
             "best_prior_bit_len {0} too high",
             best_prior_bit_len
         );

--- a/src/structs/neighbor_summary.rs
+++ b/src/structs/neighbor_summary.rs
@@ -10,7 +10,7 @@ use crate::enabled_features::EnabledFeatures;
 
 use super::{block_based_image::AlignedBlock, quantization_tables::QuantizationTables};
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct NeighborSummary {
     edge_pixels_h: [i16; 8],
 

--- a/src/structs/quantization_tables.rs
+++ b/src/structs/quantization_tables.rs
@@ -72,7 +72,9 @@ impl QuantizationTables {
         }
 
         for coord in 0..64 {
-            self.freq_max[coord] = FREQ_MAX[coord] + self.quantization_table[coord] - 1;
+            self.freq_max[coord] = FREQ_MAX[coord]
+                .wrapping_add(self.quantization_table[coord])
+                .wrapping_sub(1);
             if self.quantization_table[coord] != 0 {
                 self.freq_max[coord] /= self.quantization_table[coord];
             }


### PR DESCRIPTION
Unfortunately Lepton doesn't check to make sure that coefficients * quantization table aren't greater than 16 bits. This can cause all kinds of weird behavior so we need to make sure that this behavior doesn't change.

Tests showed found a regression in #67 that count7x7 is too small by one and would cause an assertion decoding some images.

Explicitly import rand_chacha instead of using the standard library for generating random numbers. Since the standard library can change implementations, we want it to be fixed so that our hashes don't change.