### PR TITLE
fix incorrect upcast of quantization table value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,18 +28,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f538837af36e6f6a9be0faa67f9a314f8119e4e4b5867c6ab40ed60360142519"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 dependencies = [
  "backtrace",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.2.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1fdabc7756949593fe60f30ec81974b613357de856987752631dea1e3394c80"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
@@ -64,9 +64,9 @@ checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
 
 [[package]]
 name = "bytemuck"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d68c57235a3a081186990eca2867354726650f42f7516ca50c28d6281fd15"
+checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
 
 [[package]]
 name = "byteorder"
@@ -76,9 +76,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
 
 [[package]]
 name = "cfg-if"
@@ -108,9 +108,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.4.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -136,9 +136,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "default-boxed"
@@ -171,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "3dca9240753cf90908d7e4aac30f630662b02aebaa1b58a3cadabdb23385b58b"
 
 [[package]]
 name = "flate2"
@@ -241,7 +241,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -282,9 +282,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
@@ -339,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "log"
@@ -357,9 +357,9 @@ checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
+checksum = "87dfd01fe195c66b572b37921ad8803d010623c0aca821bea2302239d155cdae"
 dependencies = [
  "adler",
 ]
@@ -414,9 +414,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
+checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
 dependencies = [
  "unicode-ident",
 ]
@@ -511,9 +511,9 @@ checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "relative-path"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
@@ -540,15 +540,15 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.60",
+ "syn 2.0.65",
  "unicode-ident",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -561,9 +561,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "safe_arch"
@@ -576,28 +576,28 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.199"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
+checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.199"
+version = "1.0.202"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
+checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.60",
+ "syn 2.0.65",
 ]
 
 [[package]]
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.60"
+version = "2.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
+checksum = "d2863d96a84c6439701d7a38f9de935ec562c8832cc55d1dde0f513b52fad106"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -720,9 +720,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wide"
-version = "0.7.17"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f0e39d2c603fdc0504b12b458cf1f34e0b937ed2f4f2dc20796e3e86f34e11f"
+checksum = "21e005a4cc35784183a9e39cb22e9a9c46353ef6a7f113fd8d36ddc58c15ef3c"
 dependencies = [
  "bytemuck",
  "safe_arch",

--- a/src/structs/idct.rs
+++ b/src/structs/idct.rs
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 use bytemuck::{cast, cast_ref};
-use wide::{i16x8, i32x8};
+use wide::{i16x8, i32x8, u16x8};
 
 use super::block_based_image::AlignedBlock;
 
@@ -31,19 +31,8 @@ const R2: i32 = 181; // 256/sqrt(2)
 
 #[inline(always)]
 pub fn get_q(offset: usize, q_transposed: &AlignedBlock) -> i32x8 {
-    let q: &[u16; 64] = cast_ref(q_transposed.get_block());
-
-    // unsigned zero extend to 32 bit
-    i32x8::new([
-        i32::from(q[offset * 8]),
-        i32::from(q[offset * 8 + 1]),
-        i32::from(q[offset * 8 + 2]),
-        i32::from(q[offset * 8 + 3]),
-        i32::from(q[offset * 8 + 4]),
-        i32::from(q[offset * 8 + 5]),
-        i32::from(q[offset * 8 + 6]),
-        i32::from(q[offset * 8 + 7]),
-    ])
+    let rows: &[u16x8; 8] = cast_ref(q_transposed.get_block());
+    i32x8::from_u16x8(rows[offset])
 }
 
 #[inline(never)]

--- a/src/structs/idct.rs
+++ b/src/structs/idct.rs
@@ -31,8 +31,19 @@ const R2: i32 = 181; // 256/sqrt(2)
 
 #[inline(always)]
 pub fn get_q(offset: usize, q_transposed: &AlignedBlock) -> i32x8 {
-    let rows: &[i16x8; 8] = cast_ref(q_transposed.get_block());
-    i32x8::from_i16x8(rows[offset])
+    let q: &[u16; 64] = cast_ref(q_transposed.get_block());
+
+    // unsigned zero extend to 32 bit
+    i32x8::new([
+        i32::from(q[offset * 8]),
+        i32::from(q[offset * 8 + 1]),
+        i32::from(q[offset * 8 + 2]),
+        i32::from(q[offset * 8 + 3]),
+        i32::from(q[offset * 8 + 4]),
+        i32::from(q[offset * 8 + 5]),
+        i32::from(q[offset * 8 + 6]),
+        i32::from(q[offset * 8 + 7]),
+    ])
 }
 
 #[inline(never)]

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -695,7 +695,8 @@ fn roundtrip_ones() {
 /// way the math operations are performed (for example overflow or bitness)
 #[test]
 fn roundtrip_large_coef() {
-    let block = AlignedBlock::new([1023; 64]);
+    // largest coefficient that doesn't cause a DC overflow
+    let block = AlignedBlock::new([-1010; 64]);
 
     roundtrip_read_write_coefficients(
         &block,
@@ -703,8 +704,8 @@ fn roundtrip_large_coef() {
         &block,
         &block,
         [1; 64],
-        0xcf268c76674a5c83,
-        &EnabledFeatures::compat_lepton_scalar_read(),
+        0x9e97dff50bc0188,
+        &EnabledFeatures::compat_lepton_vector_read(),
     );
 
     // now test with maximum quantization table. In theory this is legal according
@@ -717,8 +718,8 @@ fn roundtrip_large_coef() {
         &block,
         &block,
         [65535; 64],
-        0xc4410bb82397c41f,
-        &EnabledFeatures::compat_lepton_scalar_read(),
+        0xe9a6f36fcaf42727,
+        &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
 
@@ -727,10 +728,10 @@ fn roundtrip_large_coef() {
 fn roundtrip_random_seed() {
     use rand::Rng;
 
-    // the 76 seed is a choice that doesn't overflow the DC coefficient
+    // the 22 seed is a choice that doesn't overflow the DC coefficient
     // since the encoder is somewhat picky if the DC estimate overflows
     // it also has different behavior for 32 and 16 bit codepath
-    let mut rng = crate::helpers::get_rand_from_seed([76; 32]);
+    let mut rng = crate::helpers::get_rand_from_seed([22; 32]);
 
     let arr = [0i16; 64];
 
@@ -741,26 +742,28 @@ fn roundtrip_random_seed() {
     let qt = arr.map(|_| rng.gen_range(1u16..=65535));
 
     // using 32 bit math (test emulating both scalar and vector C++ code)
-    roundtrip_read_write_coefficients(
+    let a = roundtrip_read_write_coefficients(
         &left,
         &above,
         &above_left,
         &here,
         qt,
-        0xd0fef0d9d11bc639,
+        0x8f043f2ae83c2d5a,
         &EnabledFeatures::compat_lepton_scalar_read(),
     );
 
     // using 16 bit math
-    roundtrip_read_write_coefficients(
+    let b = roundtrip_read_write_coefficients(
         &left,
         &above,
         &above_left,
         &here,
         qt,
-        0x22c0214bde6c7a70,
+        0x99675a04115a3b3b,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
+
+    assert!(a != b);
 }
 
 /// tests a pattern where all the coefficients are unique to make sure we don't mix up anything
@@ -848,7 +851,7 @@ fn roundtrip_read_write_coefficients(
     qt: [u16; 64],
     verified_output: u64,
     features: &EnabledFeatures,
-) {
+) -> u64 {
     use crate::structs::{
         block_based_image::EMPTY_BLOCK, lepton_decoder::read_coefficient_block,
         neighbor_summary::NEIGHBOR_DATA_EMPTY, vpx_bool_reader::VPXBoolReader,
@@ -1070,4 +1073,6 @@ fn roundtrip_read_write_coefficients(
             "Hash mismatch. Unexpected change in model behavior/output format"
         );
     }
+
+    hash
 }


### PR DESCRIPTION
Code is upcasting quantization table value from u16 to i32 via an i16, which means that 32768+ gets incorrectly promoted to a negative i32. Verified that the C++ version uses a zero-extending upcast from u16. Originally the lepton version also used a zero-extending upcast but at some point I optimized it not realizing the range difference.

This is a somewhat hypothetical difference since 8 bit JPEGs (which are the only ones we allow) aren't allowed to have 16 bit quantization tables by the JPEG standard, although the C++ lepton doesn't actually enforce this, so in theory there could be a bad JPEG that gets compressed this way. 

However, now that there are better testcases for these extremes, we can catch errors here.