### PR TITLE
Fix of calc_sign_index

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -78,7 +78,7 @@ pub const fn bitn(c: u16, n: u16) -> u8 {
 }
 
 #[inline(always)]
-pub fn calc_sign_index(val: i32) -> usize {
+pub fn calc_sign_index(val: i16) -> usize {
     if val == 0 {
         0
     } else {

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -364,7 +364,7 @@ impl ModelPerColor {
 
         let mut coef = 0;
         if length != 0 {
-            let sign = &mut self.sign_counts[calc_sign_index(best_prior)][best_prior_bit_len];
+            let sign = &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
 
             let neg = !bool_reader
                 .get(sign, ModelComponent::Edge(ModelSubComponent::Sign))
@@ -464,7 +464,7 @@ impl ModelPerColor {
         )?;
 
         if coef != 0 {
-            let sign = &mut self.sign_counts[calc_sign_index(best_prior)][best_prior_bit_len];
+            let sign = &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
 
             bool_writer.put(
                 coef >= 0,
@@ -623,7 +623,7 @@ impl Model {
         let exp = &mut self.counts_dc[len_abs_mxm_clamp].exponent_counts
             [len_abs_offset_to_closest_edge as usize];
         let sign = &mut self.per_color[color_index].sign_counts[0]
-            [calc_sign_index(uncertainty2 as i32) + 1]; // +1 to separate from sign_counts[0][0]
+            [calc_sign_index(uncertainty2) + 1]; // +1 to separate from sign_counts[0][0]
         let bits = &mut self.counts_dc[len_abs_mxm_clamp].residual_noise_counts;
 
         (exp, sign, bits)

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -364,6 +364,8 @@ impl ModelPerColor {
 
         let mut coef = 0;
         if length != 0 {
+            // best_prior in the initial Lepton implementation is stored as i32,
+            // but the sign here is taken from its truncated i16 value
             let sign =
                 &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
 
@@ -465,6 +467,8 @@ impl ModelPerColor {
         )?;
 
         if coef != 0 {
+            // best_prior in the initial Lepton implementation is stored as i32,
+            // but the sign here is taken from its truncated i16 value
             let sign =
                 &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
 

--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -364,7 +364,8 @@ impl ModelPerColor {
 
         let mut coef = 0;
         if length != 0 {
-            let sign = &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
+            let sign =
+                &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
 
             let neg = !bool_reader
                 .get(sign, ModelComponent::Edge(ModelSubComponent::Sign))
@@ -464,7 +465,8 @@ impl ModelPerColor {
         )?;
 
         if coef != 0 {
-            let sign = &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
+            let sign =
+                &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
 
             bool_writer.put(
                 coef >= 0,
@@ -622,8 +624,8 @@ impl Model {
 
         let exp = &mut self.counts_dc[len_abs_mxm_clamp].exponent_counts
             [len_abs_offset_to_closest_edge as usize];
-        let sign = &mut self.per_color[color_index].sign_counts[0]
-            [calc_sign_index(uncertainty2) + 1]; // +1 to separate from sign_counts[0][0]
+        let sign =
+            &mut self.per_color[color_index].sign_counts[0][calc_sign_index(uncertainty2) + 1]; // +1 to separate from sign_counts[0][0]
         let bits = &mut self.counts_dc[len_abs_mxm_clamp].residual_noise_counts;
 
         (exp, sign, bits)


### PR DESCRIPTION
To get in line with initial Lepton implementation we need to use sign of i16 truncated prior.

See https://github.com/dropbox/lepton/blob/master/src/vp8/model/model.hh#L1114