### PR TITLE
Precalculate Non-zero divisors for lak

### DIFF
--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -529,13 +529,13 @@ fn decode_one_edge<R: Read, const ALL_PRESENT: bool, const HORIZONTAL: bool>(
 
     let mut coord_tr = delta;
 
-    for _lane in 0..7 {
+    for lane in 0..7 {
         if num_non_zeros_edge == 0 {
             break;
         }
 
         let best_prior =
-            pt.calc_coefficient_context8_lak::<ALL_PRESENT, HORIZONTAL>(qt, coord_tr, pred);
+            pt.calc_coefficient_context8_lak::<ALL_PRESENT, HORIZONTAL>(qt, lane, pred);
 
         let coef = model_per_color.read_edge_coefficient(
             bool_reader,

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -586,13 +586,13 @@ fn encode_one_edge<W: Write, const ALL_PRESENT: bool, const HORIZONTAL: bool>(
 
     let mut coord_tr = delta;
 
-    for _lane in 0..7 {
+    for lane in 0..7 {
         if num_non_zeros_edge == 0 {
             break;
         }
 
         let best_prior =
-            pt.calc_coefficient_context8_lak::<ALL_PRESENT, HORIZONTAL>(qt, coord_tr, pred);
+            pt.calc_coefficient_context8_lak::<ALL_PRESENT, HORIZONTAL>(qt, lane, pred);
 
         let coef = block.get_coefficient(coord_tr);
 

--- a/src/structs/probability_tables.rs
+++ b/src/structs/probability_tables.rs
@@ -208,7 +208,7 @@ impl ProbabilityTables {
     pub fn calc_coefficient_context8_lak<const ALL_PRESENT: bool, const HORIZONTAL: bool>(
         &self,
         qt: &QuantizationTables,
-        coefficient_tr: usize,
+        lane: usize,
         pred: &[i32; 8],
     ) -> i32 {
         if !ALL_PRESENT
@@ -217,14 +217,7 @@ impl ProbabilityTables {
             return 0;
         }
 
-        let mut best_prior: i32 = pred[if HORIZONTAL {
-            coefficient_tr >> 3
-        } else {
-            coefficient_tr
-        }];
-        best_prior /= (qt.get_quantization_table_transposed()[coefficient_tr] as i32) << 13;
-
-        best_prior
+        pred[lane + 1] / qt.get_quantization_table_divisors::<HORIZONTAL>()[lane + 1].get()
     }
 
     pub fn adv_predict_dc_pix<const ALL_PRESENT: bool>(

--- a/src/structs/quantization_tables.rs
+++ b/src/structs/quantization_tables.rs
@@ -13,9 +13,16 @@ use super::jpeg_header::JPegHeader;
 
 pub struct QuantizationTables {
     quantization_table: [u16; 64],
+
+    /// transposed version of quantization table
     quantization_table_transposed: [u16; 64],
 
+    /// precalculated divisors * 8192 for the top row of the quantization table for final step of lak calculation
+    /// compiler sees non-zero to avoid having to check for division-by-zero
     quantization_table_divisors_horiz: [NonZeroI32; 8],
+
+    /// precalculated divisors * 8192 for the left column of the quantization table for final step of lak calculation
+    /// compiler sees non-zero to avoid having to check for division-by-zero
     quantization_table_divisors_vert: [NonZeroI32; 8],
 
     // Values for discrimination between "regular" and "noise" part of


### PR DESCRIPTION
Simplify division step in Lak calculations so that we don't need to check for divide by zero.