### PR TITLE
Unify the neighbor generation for DC prediction

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -77,9 +77,6 @@ pub const MAX_THREADS: usize = 8;
 
 pub const RESIDUAL_NOISE_FLOOR: usize = 7;
 
-// IDCT of Lepton provides pixels multiplied by that amount
-pub const X_IDCT_SCALE: i32 = 8;
-
 pub const LEPTON_VERSION: u8 = 1; // Lepton version, same as used by Lepton C++ since we support the same format
 pub const MAX_FILE_SIZE_BYTES: i32 = 128 * 1024 * 1024;
 //pub const LogMaxNumerator : i32 = 18;

--- a/src/structs/block_based_image.rs
+++ b/src/structs/block_based_image.rs
@@ -271,17 +271,4 @@ impl AlignedBlock {
     pub fn get_transposed_from_zigzag(&self, index: usize) -> i16 {
         return self.raw_data[usize::from(ZIGZAG_TO_TRANSPOSED[index])];
     }
-
-    pub fn from_stride(&self, offset: usize, stride: usize) -> i16x8 {
-        return i16x8::new([
-            self.raw_data[offset],
-            self.raw_data[offset + (1 * stride)],
-            self.raw_data[offset + (2 * stride)],
-            self.raw_data[offset + (3 * stride)],
-            self.raw_data[offset + (4 * stride)],
-            self.raw_data[offset + (5 * stride)],
-            self.raw_data[offset + (6 * stride)],
-            self.raw_data[offset + (7 * stride)],
-        ]);
-    }
 }

--- a/src/structs/block_based_image.rs
+++ b/src/structs/block_based_image.rs
@@ -271,4 +271,17 @@ impl AlignedBlock {
     pub fn get_transposed_from_zigzag(&self, index: usize) -> i16 {
         return self.raw_data[usize::from(ZIGZAG_TO_TRANSPOSED[index])];
     }
+
+    pub fn from_stride(&self, offset: usize, stride: usize) -> i16x8 {
+        return i16x8::new([
+            self.raw_data[offset],
+            self.raw_data[offset + (1 * stride)],
+            self.raw_data[offset + (2 * stride)],
+            self.raw_data[offset + (3 * stride)],
+            self.raw_data[offset + (4 * stride)],
+            self.raw_data[offset + (5 * stride)],
+            self.raw_data[offset + (6 * stride)],
+            self.raw_data[offset + (7 * stride)],
+        ]);
+    }
 }

--- a/src/structs/idct.rs
+++ b/src/structs/idct.rs
@@ -133,7 +133,7 @@ use bytemuck::cast_ref;
 
 #[cfg(test)]
 #[inline(always)]
-pub fn get_q(offset: usize, q_transposed: &AlignedBlock) -> i32x8 {
+fn get_q(offset: usize, q_transposed: &AlignedBlock) -> i32x8 {
     use wide::u16x8;
 
     let rows: &[u16x8; 8] = cast_ref(q_transposed.get_block());
@@ -142,7 +142,7 @@ pub fn get_q(offset: usize, q_transposed: &AlignedBlock) -> i32x8 {
 
 #[cfg(test)]
 #[inline(always)]
-pub fn get_c(offset: usize, q_transposed: &AlignedBlock) -> i32x8 {
+fn get_c(offset: usize, q_transposed: &AlignedBlock) -> i32x8 {
     let rows: &[i16x8; 8] = cast_ref(q_transposed.get_block());
     i32x8::from_i16x8(rows[offset])
 }

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -244,8 +244,8 @@ pub fn read_coefficient_block<const ALL_PRESENT: bool, R: Read>(
 
     // read how many of these are non-zero, which is used both
     // to terminate the loop early and as a predictor for the model
-    let num_non_zeros_7x7 = model_per_color
-        .read_non_zero_7x7_count(bool_reader, num_non_zeros_7x7_context_bin)?;
+    let num_non_zeros_7x7 =
+        model_per_color.read_non_zero_7x7_count(bool_reader, num_non_zeros_7x7_context_bin)?;
 
     if num_non_zeros_7x7 > 49 {
         // most likely a stream or model synchronization error
@@ -278,13 +278,12 @@ pub fn read_coefficient_block<const ALL_PRESENT: bool, R: Read>(
         for (zig49, &coord_tr) in UNZIGZAG_49_TR.iter().enumerate() {
             let best_prior_bit_length = u16_bit_length(best_priors[coord_tr as usize]);
 
-            let coef = model_per_color
-                .read_coef(
-                    bool_reader,
-                    zig49,
-                    num_non_zeros_bin,
-                    best_prior_bit_length as usize,
-                )?;
+            let coef = model_per_color.read_coef(
+                bool_reader,
+                zig49,
+                num_non_zeros_bin,
+                best_prior_bit_length as usize,
+            )?;
 
             if coef != 0 {
                 // here we calculate the furthest x and y coordinates that have non-zero coefficients
@@ -340,13 +339,12 @@ pub fn read_coefficient_block<const ALL_PRESENT: bool, R: Read>(
     let q0 = qt.get_quantization_table()[0] as i32;
     let predicted_dc = pt.adv_predict_dc_pix::<ALL_PRESENT>(&raster, q0, &neighbor_data, features);
 
-    let coef = model
-        .read_dc(
-            bool_reader,
-            color_index,
-            predicted_dc.uncertainty,
-            predicted_dc.uncertainty2,
-        )?;
+    let coef = model.read_dc(
+        bool_reader,
+        color_index,
+        predicted_dc.uncertainty,
+        predicted_dc.uncertainty2,
+    )?;
 
     output.set_dc(ProbabilityTables::adv_predict_or_unpredict_dc(
         coef,

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -245,8 +245,7 @@ pub fn read_coefficient_block<const ALL_PRESENT: bool, R: Read>(
     // read how many of these are non-zero, which is used both
     // to terminate the loop early and as a predictor for the model
     let num_non_zeros_7x7 = model_per_color
-        .read_non_zero_7x7_count(bool_reader, num_non_zeros_7x7_context_bin)
-        .context(here!())?;
+        .read_non_zero_7x7_count(bool_reader, num_non_zeros_7x7_context_bin)?;
 
     if num_non_zeros_7x7 > 49 {
         // most likely a stream or model synchronization error
@@ -285,8 +284,7 @@ pub fn read_coefficient_block<const ALL_PRESENT: bool, R: Read>(
                     zig49,
                     num_non_zeros_bin,
                     best_prior_bit_length as usize,
-                )
-                .context(here!())?;
+                )?;
 
             if coef != 0 {
                 // here we calculate the furthest x and y coordinates that have non-zero coefficients
@@ -348,8 +346,8 @@ pub fn read_coefficient_block<const ALL_PRESENT: bool, R: Read>(
             color_index,
             predicted_dc.uncertainty,
             predicted_dc.uncertainty2,
-        )
-        .context(here!())?;
+        )?;
+
     output.set_dc(ProbabilityTables::adv_predict_or_unpredict_dc(
         coef,
         true,
@@ -358,8 +356,8 @@ pub fn read_coefficient_block<const ALL_PRESENT: bool, R: Read>(
 
     // neighbor summary is used as a predictor for the next block
     let neighbor_summary = NeighborSummary::new(
-        predicted_dc.edge_pixels_h,
-        predicted_dc.edge_pixels_v,
+        predicted_dc.next_edge_pixels_h,
+        predicted_dc.next_edge_pixels_v,
         output.get_dc() as i32 * q0,
         num_non_zeros_7x7,
         horiz_pred,

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -358,13 +358,12 @@ pub fn read_coefficient_block<const ALL_PRESENT: bool, R: Read>(
 
     // neighbor summary is used as a predictor for the next block
     let neighbor_summary = NeighborSummary::new(
-        predicted_dc.h_delta,
-        predicted_dc.v_delta,
+        predicted_dc.edge_pixels_h,
+        predicted_dc.edge_pixels_v,
         output.get_dc() as i32 * q0,
         num_non_zeros_7x7,
         horiz_pred,
         vert_pred,
-        features,
     );
 
     Ok((output, neighbor_summary))

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -358,7 +358,8 @@ pub fn read_coefficient_block<const ALL_PRESENT: bool, R: Read>(
 
     // neighbor summary is used as a predictor for the next block
     let neighbor_summary = NeighborSummary::new(
-        &predicted_dc.advanced_predict_dc_pixels_sans_dc,
+        predicted_dc.h_delta,
+        predicted_dc.v_delta,
         output.get_dc() as i32 * q0,
         num_non_zeros_7x7,
         horiz_pred,

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -390,7 +390,8 @@ pub fn write_coefficient_block<const ALL_PRESENT: bool, W: Write>(
 
     // neighbor summary is used as a predictor for the next block
     let neighbor_summary = NeighborSummary::new(
-        &predicted_val.advanced_predict_dc_pixels_sans_dc,
+        predicted_val.h_delta,
+        predicted_val.v_delta,
         here_tr.get_dc() as i32 * q0,
         num_non_zeros_7x7,
         horiz_pred,

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -390,13 +390,12 @@ pub fn write_coefficient_block<const ALL_PRESENT: bool, W: Write>(
 
     // neighbor summary is used as a predictor for the next block
     let neighbor_summary = NeighborSummary::new(
-        predicted_val.h_delta,
-        predicted_val.v_delta,
+        predicted_val.edge_pixels_h,
+        predicted_val.edge_pixels_v,
         here_tr.get_dc() as i32 * q0,
         num_non_zeros_7x7,
         horiz_pred,
         vert_pred,
-        features,
     );
 
     Ok(neighbor_summary)

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -390,8 +390,8 @@ pub fn write_coefficient_block<const ALL_PRESENT: bool, W: Write>(
 
     // neighbor summary is used as a predictor for the next block
     let neighbor_summary = NeighborSummary::new(
-        predicted_val.edge_pixels_h,
-        predicted_val.edge_pixels_v,
+        predicted_val.next_edge_pixels_h,
+        predicted_val.next_edge_pixels_v,
         here_tr.get_dc() as i32 * q0,
         num_non_zeros_7x7,
         horiz_pred,

--- a/src/structs/neighbor_summary.rs
+++ b/src/structs/neighbor_summary.rs
@@ -45,8 +45,8 @@ impl NeighborSummary {
         vert_pred: i32x8,
     ) -> Self {
         NeighborSummary {
-            edge_pixels_h: edge_pixels_h + (dc_deq + 128 * X_IDCT_SCALE) as i16,
-            edge_pixels_v: edge_pixels_v + (dc_deq + 128 * X_IDCT_SCALE) as i16,
+            edge_pixels_h: edge_pixels_h + (dc_deq as i16),
+            edge_pixels_v: edge_pixels_v + (dc_deq as i16),
             edge_coefs_h: horiz_pred,
             edge_coefs_v: vert_pred,
             num_non_zeros: num_non_zeros_7x7,

--- a/src/structs/neighbor_summary.rs
+++ b/src/structs/neighbor_summary.rs
@@ -8,8 +8,6 @@ use std::num::Wrapping;
 
 use wide::{i16x8, i32x8};
 
-use crate::consts::X_IDCT_SCALE;
-
 #[derive(Copy, Clone, PartialEq, Debug)]
 pub struct NeighborSummary {
     edge_pixels_h: i16x8,

--- a/src/structs/neighbor_summary.rs
+++ b/src/structs/neighbor_summary.rs
@@ -39,7 +39,8 @@ impl Default for NeighborSummary {
 
 impl NeighborSummary {
     pub fn new(
-        here_idct: &AlignedBlock,
+        h_delta: i16x8,
+        v_delta: i16x8,
         dc_deq: i32,
         num_non_zeros_7x7: u8,
         horiz_pred: i32x8,
@@ -47,8 +48,8 @@ impl NeighborSummary {
         features: &EnabledFeatures,
     ) -> Self {
         NeighborSummary {
-            edge_pixels_h: Self::set_horizontal(here_idct, dc_deq, features),
-            edge_pixels_v: Self::set_vertical(here_idct, dc_deq, features),
+            edge_pixels_h: Self::set_horizontal(h_delta, dc_deq, features),
+            edge_pixels_v: Self::set_vertical(v_delta, dc_deq, features),
             edge_coefs_h: horiz_pred,
             edge_coefs_v: vert_pred,
             num_non_zeros: num_non_zeros_7x7,
@@ -67,35 +68,17 @@ impl NeighborSummary {
         return self.edge_pixels_h;
     }
 
-    fn set_pixel_pred(curr: i16x8, prev: i16x8, dc_deq: i32, features: &EnabledFeatures) -> i16x8 {
+    fn set_pixel_pred(v: i16x8, dc_deq: i32, features: &EnabledFeatures) -> i16x8 {
         // Sadly C++ version has a bug where it uses 16 bit math in the SIMD path and 32 bit math in the scalar path
-        if features.use_16bit_dc_estimate {
-            let delta = curr - prev;
-            // ((delta - (delta >> 15)) >> 1) = delta / 2
-            curr + (dc_deq + 128 * X_IDCT_SCALE) as i16 + ((delta - (delta >> 15)) >> 1)
-        } else {
-            let curr = i32x8::from_i16x8(curr);
-            let prev = i32x8::from_i16x8(prev);
-            let delta = curr - prev;
-            // ((delta - (delta >> 31)) >> 1) = delta / 2
-            i16x8::from_i32x8_truncate(
-                curr + (dc_deq + 128 * X_IDCT_SCALE) + ((delta - (delta >> 31)) >> 1),
-            )
-        }
+        v + (dc_deq + 128 * X_IDCT_SCALE) as i16
     }
 
-    fn set_horizontal(here_idct: &AlignedBlock, dc_deq: i32, features: &EnabledFeatures) -> i16x8 {
-        let curr = here_idct.from_stride(56, 1);
-        let prev = here_idct.from_stride(48, 1);
-
-        Self::set_pixel_pred(curr, prev, dc_deq, features)
+    fn set_horizontal(h_delta: i16x8, dc_deq: i32, features: &EnabledFeatures) -> i16x8 {
+        Self::set_pixel_pred(h_delta, dc_deq, features)
     }
 
-    fn set_vertical(here_idct: &AlignedBlock, dc_deq: i32, features: &EnabledFeatures) -> i16x8 {
-        let curr = here_idct.from_stride(7, 8);
-        let prev = here_idct.from_stride(6, 8);
-
-        Self::set_pixel_pred(curr, prev, dc_deq, features)
+    fn set_vertical(v_delta: i16x8, dc_deq: i32, features: &EnabledFeatures) -> i16x8 {
+        Self::set_pixel_pred(v_delta, dc_deq, features)
     }
 
     pub fn get_vertical_coef(&self) -> i32x8 {

--- a/src/structs/probability_tables.rs
+++ b/src/structs/probability_tables.rs
@@ -31,8 +31,8 @@ pub struct PredictDCResult {
     pub predicted_dc: i32,
     pub uncertainty: i16,
     pub uncertainty2: i16,
-    pub h_delta: i16x8,
-    pub v_delta: i16x8,
+    pub edge_pixels_h: i16x8,
+    pub edge_pixels_v: i16x8,
 }
 
 impl ProbabilityTables {
@@ -267,7 +267,7 @@ impl ProbabilityTables {
 
         let prev = pixels_sans_dc.as_i16x8(6);
         let curr = pixels_sans_dc.as_i16x8(7);
-        let h_delta = calc_pred(curr, prev, enabled_features.use_16bit_dc_estimate);
+        let edge_pixels_h = calc_pred(curr, prev, enabled_features.use_16bit_dc_estimate);
 
         let t = pixels_sans_dc.transpose();
 
@@ -278,7 +278,7 @@ impl ProbabilityTables {
 
         let prev = t.as_i16x8(6);
         let curr = t.as_i16x8(7);
-        let v_delta = calc_pred(curr, prev, enabled_features.use_16bit_dc_estimate);
+        let edge_pixels_v = calc_pred(curr, prev, enabled_features.use_16bit_dc_estimate);
 
         let min_dc;
         let max_dc;
@@ -314,8 +314,8 @@ impl ProbabilityTables {
                 predicted_dc: 0,
                 uncertainty: 0,
                 uncertainty2: 0,
-                h_delta: h_delta,
-                v_delta: v_delta,
+                edge_pixels_h,
+                edge_pixels_v,
             };
         }
 
@@ -335,8 +335,8 @@ impl ProbabilityTables {
             predicted_dc: (avgmed / q0 + 4) >> 3,
             uncertainty: uncertainty_val,
             uncertainty2: uncertainty2_val,
-            h_delta,
-            v_delta,
+            edge_pixels_h,
+            edge_pixels_v,
         };
     }
 }

--- a/src/structs/probability_tables.rs
+++ b/src/structs/probability_tables.rs
@@ -260,16 +260,13 @@ impl ProbabilityTables {
             }
         }
 
-        // transpose so we can get the vertical rows as single vectors
-        let transposed = pixels_sans_dc.transpose();
-
         let a1 = pixels_sans_dc.as_i16x8(0);
         let a2 = pixels_sans_dc.as_i16x8(1);
         let v_pred =
             calc_pred(a1, a2, enabled_features.use_16bit_adv_predict) + 128 * X_IDCT_SCALE as i16;
 
-        let a1 = transposed.as_i16x8(0);
-        let a2 = transposed.as_i16x8(1);
+        let a1 = pixels_sans_dc.from_stride(0, 8);
+        let a2 = pixels_sans_dc.from_stride(1, 8);
         let h_pred =
             calc_pred(a1, a2, enabled_features.use_16bit_adv_predict) + 128 * X_IDCT_SCALE as i16;
 
@@ -277,8 +274,9 @@ impl ProbabilityTables {
         let a2 = pixels_sans_dc.as_i16x8(6);
         let next_edge_pixels_v = calc_pred(a1, a2, enabled_features.use_16bit_dc_estimate);
 
-        let a1 = transposed.as_i16x8(7);
-        let a2 = transposed.as_i16x8(6);
+        let a1 = pixels_sans_dc.from_stride(7, 8);
+        let a2 = pixels_sans_dc.from_stride(6, 8);
+
         let next_edge_pixels_h = calc_pred(a1, a2, enabled_features.use_16bit_dc_estimate);
 
         let min_dc;

--- a/src/structs/probability_tables.rs
+++ b/src/structs/probability_tables.rs
@@ -262,13 +262,11 @@ impl ProbabilityTables {
 
         let a1 = pixels_sans_dc.as_i16x8(0);
         let a2 = pixels_sans_dc.as_i16x8(1);
-        let v_pred =
-            calc_pred(a1, a2, enabled_features.use_16bit_adv_predict) + 128 * X_IDCT_SCALE as i16;
+        let v_pred = calc_pred(a1, a2, enabled_features.use_16bit_adv_predict);
 
         let a1 = pixels_sans_dc.from_stride(0, 8);
         let a2 = pixels_sans_dc.from_stride(1, 8);
-        let h_pred =
-            calc_pred(a1, a2, enabled_features.use_16bit_adv_predict) + 128 * X_IDCT_SCALE as i16;
+        let h_pred = calc_pred(a1, a2, enabled_features.use_16bit_adv_predict);
 
         let a1 = pixels_sans_dc.as_i16x8(7);
         let a2 = pixels_sans_dc.as_i16x8(6);


### PR DESCRIPTION
adv_predict_dc_pix can generate the edge information in one place as opposed to doing the calculation in two seperate places. This allows us to use a transpose to read the data more quickly than read the information sparsely. It also means that we only need to do the delta calculations in one place.