### PR TITLE
Local stream state

### DIFF
--- a/src/structs/model.rs
+++ b/src/structs/model.rs
@@ -370,7 +370,7 @@ impl ModelPerColor {
                 &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
 
             let neg = !bool_reader
-                .get(sign, ModelComponent::Edge(ModelSubComponent::Sign))
+                .get_bit(sign, ModelComponent::Edge(ModelSubComponent::Sign))
                 .context(here!())?;
 
             coef = 1;
@@ -388,7 +388,7 @@ impl ModelPerColor {
 
                     let mut decoded_so_far = 1;
                     while i >= min_threshold {
-                        let cur_bit = bool_reader.get(
+                        let cur_bit = bool_reader.get_bit(
                             &mut thresh_prob[decoded_so_far],
                             ModelComponent::Edge(ModelSubComponent::Residual),
                         )? as i16;
@@ -472,7 +472,7 @@ impl ModelPerColor {
             let sign =
                 &mut self.sign_counts[calc_sign_index(best_prior as i16)][best_prior_bit_len];
 
-            bool_writer.put(
+            bool_writer.put_bit(
                 coef >= 0,
                 sign,
                 ModelComponent::Edge(ModelSubComponent::Sign),
@@ -492,7 +492,7 @@ impl ModelPerColor {
                     let mut encoded_so_far = 1;
                     while i >= min_threshold {
                         let cur_bit = (abs_coef & (1 << i)) != 0;
-                        bool_writer.put(
+                        bool_writer.put_bit(
                             cur_bit,
                             &mut thresh_prob[encoded_so_far],
                             ModelComponent::Edge(ModelSubComponent::Residual),
@@ -659,7 +659,7 @@ impl Model {
 
         let mut coef: i16 = 0;
         if length != 0 {
-            let neg = !bool_reader.get(sign_branch, sign_cmp)?;
+            let neg = !bool_reader.get_bit(sign_branch, sign_cmp)?;
             if length > 1 {
                 coef = bool_reader.get_n_bits(length - 1, bits_branch, bits_cmp)? as i16;
             }
@@ -704,7 +704,7 @@ impl Model {
 
         bool_writer.put_unary_encoded(coef_bit_len as usize, magnitude_branches, mag_cmp)?;
         if coef != 0 {
-            bool_writer.put(coef > 0, sign_branch, sign_cmp)?;
+            bool_writer.put_bit(coef > 0, sign_branch, sign_cmp)?;
         }
 
         if coef_bit_len > 1 {

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -52,7 +52,7 @@ impl<W: Write> VPXBoolWriter<W> {
         };
 
         let mut dummy_branch = Branch::new();
-        retval.put(false, &mut dummy_branch, ModelComponent::Dummy)?;
+        retval.put_bit(false, &mut dummy_branch, ModelComponent::Dummy)?;
 
         Ok(retval)
     }
@@ -61,76 +61,16 @@ impl<W: Write> VPXBoolWriter<W> {
         self.model_statistics.drain()
     }
 
-    #[inline(never)]
-    pub fn put_grid<const A: usize>(
-        &mut self,
-        v: u8,
-        branches: &mut [Branch; A],
-        cmp: ModelComponent,
-    ) -> Result<()> {
-        // check if A is a power of 2
-        assert!((A & (A - 1)) == 0);
-
-        let mut index = A.ilog2() - 1;
-        let mut serialized_so_far = 1;
-
-        loop {
-            let cur_bit = (v & (1 << index)) != 0;
-            self.put(cur_bit, &mut branches[serialized_so_far], cmp)?;
-
-            if index == 0 {
-                break;
-            }
-
-            serialized_so_far <<= 1;
-            serialized_so_far |= cur_bit as usize;
-
-            index -= 1;
-        }
-
-        Ok(())
-    }
-
-    #[inline(never)]
-    pub fn put_n_bits<const A: usize>(
-        &mut self,
-        bits: usize,
-        num_bits: usize,
-        branches: &mut [Branch; A],
-        cmp: ModelComponent,
-    ) -> Result<()> {
-        let mut i: i32 = (num_bits - 1) as i32;
-        while i >= 0 {
-            self.put((bits & (1 << i)) != 0, &mut branches[i as usize], cmp)?;
-            i -= 1;
-        }
-
-        Ok(())
-    }
-
-    #[inline(never)]
-    pub fn put_unary_encoded<const A: usize>(
-        &mut self,
-        v: usize,
-        branches: &mut [Branch; A],
-        cmp: ModelComponent,
-    ) -> Result<()> {
-        assert!(v <= A);
-
-        for i in 0..A {
-            let cur_bit = v != i;
-
-            self.put(cur_bit, &mut branches[i], cmp)?;
-            if !cur_bit {
-                break;
-            }
-        }
-
-        Ok(())
-    }
-
     #[inline(always)]
-    pub fn put(&mut self, value: bool, branch: &mut Branch, _cmp: ModelComponent) -> Result<()> {
+    pub fn put(
+        &mut self,
+        value: bool,
+        branch: &mut Branch,
+        tmp_value: &mut u32,
+        tmp_range: &mut u32,
+        tmp_count: &mut i32,
+        _cmp: ModelComponent,
+    ) -> Result<()> {
         #[cfg(feature = "detailed_tracing")]
         {
             // used to detect divergences between the C++ and rust versions
@@ -151,21 +91,18 @@ impl<W: Write> VPXBoolWriter<W> {
 
         let probability = branch.get_probability() as u32;
 
-        let mut tmp_range = self.range;
-        let split = 1 + (((tmp_range - 1) * probability) >> 8);
-
-        let mut tmp_low_value = self.low_value;
+        let split = 1 + (((*tmp_range - 1) * probability) >> 8);
 
         let mut shift;
         branch.record_and_update_bit(value);
 
         if value {
-            tmp_low_value += split;
-            tmp_range -= split;
+            *tmp_value += split;
+            *tmp_range -= split;
 
-            shift = (tmp_range as u8).leading_zeros() as i32;
+            shift = (*tmp_range as u8).leading_zeros() as i32;
         } else {
-            tmp_range = split;
+            *tmp_range = split;
 
             // optimizer understands that split > 0, so it can optimize this
             shift = (split as u8).leading_zeros() as i32;
@@ -177,15 +114,13 @@ impl<W: Write> VPXBoolWriter<W> {
                 .record_compression_stats(_cmp, 1, i64::from(shift));
         }
 
-        tmp_range <<= shift;
+        *tmp_range <<= shift;
+        *tmp_count += shift;
 
-        let mut tmp_count = self.count;
-        tmp_count += shift;
+        if *tmp_count >= 0 {
+            let offset = shift - *tmp_count;
 
-        if tmp_count >= 0 {
-            let offset = shift - tmp_count;
-
-            if ((tmp_low_value << (offset - 1)) & 0x80000000) != 0 {
+            if ((*tmp_value << (offset - 1)) & 0x80000000) != 0 {
                 let mut x = self.buffer.len() - 1;
 
                 while self.buffer[x] == 0xFF {
@@ -198,20 +133,16 @@ impl<W: Write> VPXBoolWriter<W> {
                 self.buffer[x] += 1;
             }
 
-            self.buffer.push((tmp_low_value >> (24 - offset)) as u8);
-            tmp_low_value <<= offset;
-            shift = tmp_count;
-            tmp_low_value &= 0xffffff;
-            tmp_count -= 8;
+            self.buffer.push((*tmp_value >> (24 - offset)) as u8);
+            *tmp_value <<= offset;
+            shift = *tmp_count;
+            *tmp_value &= 0xffffff;
+            *tmp_count -= 8;
         }
 
-        tmp_low_value <<= shift;
+        *tmp_value <<= shift;
 
-        self.count = tmp_count;
-        self.low_value = tmp_low_value;
-        self.range = tmp_range;
-
-        // check if we're out of buffer space, if yes - send the buffer to output,
+        // check if we're out of buffer space, if yes - send the buffer to output
         if self.buffer.len() > 65536 - 128 {
             self.flush_non_final_data()?;
         }
@@ -219,10 +150,149 @@ impl<W: Write> VPXBoolWriter<W> {
         Ok(())
     }
 
+    #[inline(always)]
+    pub fn put_grid<const A: usize>(
+        &mut self,
+        v: u8,
+        branches: &mut [Branch; A],
+        cmp: ModelComponent,
+    ) -> Result<()> {
+        // check if A is a power of 2
+        assert!((A & (A - 1)) == 0);
+        let mut tmp_value = self.low_value;
+        let mut tmp_range = self.range;
+        let mut tmp_count = self.count;
+
+        let mut index = A.ilog2() - 1;
+        let mut serialized_so_far = 1;
+
+        loop {
+            let cur_bit = (v & (1 << index)) != 0;
+            self.put(
+                cur_bit,
+                &mut branches[serialized_so_far],
+                &mut tmp_value,
+                &mut tmp_range,
+                &mut tmp_count,
+                cmp,
+            )?;
+
+            if index == 0 {
+                break;
+            }
+
+            serialized_so_far <<= 1;
+            serialized_so_far |= cur_bit as usize;
+
+            index -= 1;
+        }
+
+        self.low_value = tmp_value;
+        self.range = tmp_range;
+        self.count = tmp_count;
+
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub fn put_n_bits<const A: usize>(
+        &mut self,
+        bits: usize,
+        num_bits: usize,
+        branches: &mut [Branch; A],
+        cmp: ModelComponent,
+    ) -> Result<()> {
+        let mut tmp_value = self.low_value;
+        let mut tmp_range = self.range;
+        let mut tmp_count = self.count;
+
+        let mut i: i32 = (num_bits - 1) as i32;
+        while i >= 0 {
+            self.put(
+                (bits & (1 << i)) != 0,
+                &mut branches[i as usize],
+                &mut tmp_value,
+                &mut tmp_range,
+                &mut tmp_count,
+                cmp,
+            )?;
+            i -= 1;
+        }
+
+        self.low_value = tmp_value;
+        self.range = tmp_range;
+        self.count = tmp_count;
+
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub fn put_unary_encoded<const A: usize>(
+        &mut self,
+        v: usize,
+        branches: &mut [Branch; A],
+        cmp: ModelComponent,
+    ) -> Result<()> {
+        assert!(v <= A);
+
+        let mut tmp_value = self.low_value;
+        let mut tmp_range = self.range;
+        let mut tmp_count = self.count;
+
+        for i in 0..A {
+            let cur_bit = v != i;
+
+            self.put(
+                cur_bit,
+                &mut branches[i],
+                &mut tmp_value,
+                &mut tmp_range,
+                &mut tmp_count,
+                cmp,
+            )?;
+            if !cur_bit {
+                break;
+            }
+        }
+
+        self.low_value = tmp_value;
+        self.range = tmp_range;
+        self.count = tmp_count;
+
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub fn put_bit(
+        &mut self,
+        value: bool,
+        branch: &mut Branch,
+        _cmp: ModelComponent,
+    ) -> Result<()> {
+        let mut tmp_value = self.low_value;
+        let mut tmp_range = self.range;
+        let mut tmp_count = self.count;
+
+        self.put(
+            value,
+            branch,
+            &mut tmp_value,
+            &mut tmp_range,
+            &mut tmp_count,
+            _cmp,
+        )?;
+
+        self.low_value = tmp_value;
+        self.range = tmp_range;
+        self.count = tmp_count;
+
+        Ok(())
+    }
+
     pub fn finish(&mut self) -> Result<()> {
         for _i in 0..32 {
             let mut dummy_branch = Branch::new();
-            self.put(false, &mut dummy_branch, ModelComponent::Dummy)?;
+            self.put_bit(false, &mut dummy_branch, ModelComponent::Dummy)?;
         }
 
         // Ensure there's no ambigous collision with any index marker bytes
@@ -369,7 +439,7 @@ fn test_roundtrip_vpxboolwriter_single_bit() {
 
     for i in 0..1024 {
         writer
-            .put(i % 10 == 0, &mut branch, ModelComponent::Dummy)
+            .put_bit(i % 10 == 0, &mut branch, ModelComponent::Dummy)
             .unwrap();
     }
 
@@ -379,7 +449,7 @@ fn test_roundtrip_vpxboolwriter_single_bit() {
 
     let mut reader = VPXBoolReader::new(&buffer[..]).unwrap();
     for i in 0..1024 {
-        let read_value = reader.get(&mut branch, ModelComponent::Dummy).unwrap();
+        let read_value = reader.get_bit(&mut branch, ModelComponent::Dummy).unwrap();
         assert_eq!(read_value, i % 10 == 0);
     }
 }


### PR DESCRIPTION
Using local stream reader state it is possible to reduce number of reads and make branch prediction more successful.

Base performance:
```
 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.lep images/img_52MP_7k.jpg':

       444 051 506      cache-references                                                        (41,55%)
        41 665 486      cache-misses                     #    9,38% of all cache refs           (41,56%)
     8 113 956 517      cycles                                                                  (41,60%)
       440 862 436      ic_fetch_stall.ic_stall_back_pressure                                        (41,68%)
       457 817 718      stalled-cycles-frontend          #    5,64% frontend cycles idle        (41,90%)
    18 577 966 449      instructions                     #    2,29  insn per cycle            
                                                  #    0,02  stalled cycles per insn     (41,91%)
     1 848 764 378      branch-instructions                                                     (41,88%)
        66 021 856      branch-misses                    #    3,57% of all branches             (41,83%)
     3 584 631 601      ic_fetch_stall.ic_stall_any                                             (41,74%)
        20 880 168      ic_fetch_stall.ic_stall_dq_empty                                        (41,66%)
        34 198 382      l2_cache_misses_from_ic_miss                                            (41,63%)
       875 464 756      l2_latency.l2_cycles_waiting_on_fills                                        (41,58%)
            99 041      faults                                                                
                 1      migrations                                                            

       1,789772123 seconds time elapsed

       1,595364000 seconds user
       0,194044000 seconds sys
```

MR performance:
```
 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.lep images/img_52MP_7k.jpg':

       442 976 049      cache-references                                                        (41,92%)
        32 149 359      cache-misses                     #    7,26% of all cache refs           (41,79%)
     7 816 351 937      cycles                                                                  (41,71%)
       347 399 557      ic_fetch_stall.ic_stall_back_pressure                                        (41,65%)
       446 775 084      stalled-cycles-frontend          #    5,72% frontend cycles idle        (41,60%)
    18 219 535 389      instructions                     #    2,33  insn per cycle            
                                                  #    0,02  stalled cycles per insn     (41,57%)
     1 901 228 430      branch-instructions                                                     (41,63%)
        67 440 269      branch-misses                    #    3,55% of all branches             (41,55%)
     3 245 622 864      ic_fetch_stall.ic_stall_any                                             (41,68%)
        20 712 859      ic_fetch_stall.ic_stall_dq_empty                                        (41,90%)
        25 226 527      l2_cache_misses_from_ic_miss                                            (41,91%)
       876 045 483      l2_latency.l2_cycles_waiting_on_fills                                        (41,91%)
            99 039      faults                                                                
                 1      migrations                                                            

       1,726217313 seconds time elapsed

       1,531874000 seconds user
       0,193984000 seconds sys
```