### PR TITLE
compression_stats and detailed_tracing features working again

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -66,7 +66,7 @@ pub struct Metrics {
 
 impl Metrics {
     #[allow(dead_code)]
-    fn record_compression_stats(
+    pub fn record_compression_stats(
         &mut self,
         cmp: ModelComponent,
         total_bits: i64,

--- a/src/structs/lepton_file_reader.rs
+++ b/src/structs/lepton_file_reader.rs
@@ -10,6 +10,9 @@ use std::cmp::min;
 use std::io::{BufRead, Cursor, Write};
 use std::mem;
 
+#[cfg(feature = "detailed_tracing")]
+use log::info;
+
 use anyhow::{Context, Result};
 
 use crate::consts::*;
@@ -455,12 +458,12 @@ impl LeptonFileReader {
                     #[cfg(feature = "detailed_tracing")]
                     info!(
                         "ystart = {0}, segment_size = {1}, amount = {2}, offset = {3}, ob = {4}, nb = {5}",
-                        combined_thread_handoff.luma_y_start,
-                        combined_thread_handoff.segment_size,
-                        cursor.position() - _start_size,
-                        combined_thread_handoff.segment_offset_in_file,
-                        combined_thread_handoff.overhang_byte,
-                        combined_thread_handoff.num_overhang_bits
+                        thread_handoff.luma_y_start,
+                        thread_handoff.segment_size,
+                        result_buffer.len(),
+                        thread_handoff.segment_offset_in_file,
+                        thread_handoff.overhang_byte,
+                        thread_handoff.num_overhang_bits
                     );
 
                     if result_buffer.len() > thread_handoff.segment_size as usize {

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -90,6 +90,7 @@ impl<R: Read> VPXBoolReader<R> {
     // to reduce number of memory load/store operations in decoding of many-bit values.
     #[inline(always)]
     pub fn get(
+        &mut self,
         branch: &mut Branch,
         tmp_value: &mut u64,
         tmp_range: &mut u64,
@@ -138,14 +139,13 @@ impl<R: Read> VPXBoolReader<R> {
         #[cfg(feature = "detailed_tracing")]
         {
             self.hash.hash(branch.get_u64());
-            self.hash.hash(tmp_value);
-            self.hash.hash(tmp_count);
-            self.hash.hash(tmp_range);
+            self.hash.hash(*tmp_value);
+            self.hash.hash(*tmp_count);
+            self.hash.hash(*tmp_range);
 
+            let hash = self.hash.get();
             //if hash == 0x88f9c945
             {
-                let hash = self.hash.get();
-
                 print!("({0}:{1:x})", bit as u8, hash);
                 if hash % 8 == 0 {
                     println!();
@@ -180,7 +180,7 @@ impl<R: Read> VPXBoolReader<R> {
                 Self::vpx_reader_fill(&mut tmp_value, &mut tmp_count, &mut self.upstream_reader)?;
             }
 
-            let cur_bit = Self::get(
+            let cur_bit = self.get(
                 &mut branches[decoded_so_far],
                 &mut tmp_value,
                 &mut tmp_range,
@@ -220,7 +220,7 @@ impl<R: Read> VPXBoolReader<R> {
                 Self::vpx_reader_fill(&mut tmp_value, &mut tmp_count, &mut self.upstream_reader)?;
             }
 
-            let cur_bit = Self::get(
+            let cur_bit = self.get(
                 &mut branches[value],
                 &mut tmp_value,
                 &mut tmp_range,
@@ -264,7 +264,7 @@ impl<R: Read> VPXBoolReader<R> {
                 Self::vpx_reader_fill(&mut tmp_value, &mut tmp_count, &mut self.upstream_reader)?;
             }
 
-            coef |= (Self::get(
+            coef |= (self.get(
                 &mut branches[i],
                 &mut tmp_value,
                 &mut tmp_range,
@@ -291,7 +291,7 @@ impl<R: Read> VPXBoolReader<R> {
             Self::vpx_reader_fill(&mut tmp_value, &mut tmp_count, &mut self.upstream_reader)?;
         }
 
-        let bit = Self::get(branch, &mut tmp_value, &mut tmp_range, &mut tmp_count, _cmp);
+        let bit = self.get(branch, &mut tmp_value, &mut tmp_range, &mut tmp_count, _cmp);
 
         self.value = tmp_value;
         self.range = tmp_range;

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -75,9 +75,9 @@ impl<W: Write> VPXBoolWriter<W> {
         {
             // used to detect divergences between the C++ and rust versions
             self.hash.hash(branch.get_u64());
-            self.hash.hash(self.low_value);
-            self.hash.hash(self.count);
-            self.hash.hash(self.range);
+            self.hash.hash(*tmp_value);
+            self.hash.hash(*tmp_count);
+            self.hash.hash(*tmp_range);
 
             let hashed_value = self.hash.get();
             //if hashedValue == 0xe35c28fd


### PR DESCRIPTION
Somewhere these configurations were broken, this MR makes them compilable again.