### PR TITLE
centralize panic error handling

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -16,6 +16,7 @@ macro_rules! here {
 
 pub(crate) use here;
 
+/// Helper function to catch panics and convert them into the appropriate LeptonError
 pub fn catch_unwind_result<R>(
     f: impl FnOnce() -> Result<R, anyhow::Error>,
 ) -> Result<R, LeptonError> {
@@ -37,6 +38,16 @@ pub fn catch_unwind_result<R>(
             }
         }
     }
+}
+
+pub unsafe fn copy_string(str: &str, error_string_buffer_len: u64, error_string: *mut u8) {
+    // copy error string into the buffer as utf8
+    let b = std::ffi::CString::new(str).unwrap();
+    let b = b.as_bytes_with_nul();
+
+    let copy_len = std::cmp::min(b.len(), error_string_buffer_len as usize);
+    let target_error_string = std::slice::from_raw_parts_mut(error_string, copy_len);
+    target_error_string.copy_from_slice(b);
 }
 
 #[inline(always)]

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -41,6 +41,10 @@ pub fn catch_unwind_result<R>(
 }
 
 pub unsafe fn copy_string(str: &str, error_string_buffer_len: u64, error_string: *mut u8) {
+    if error_string_buffer_len == 0 {
+        return;
+    }
+
     // copy error string into the buffer as utf8
     let b = std::ffi::CString::new(str).unwrap();
     let b = b.as_bytes_with_nul();

--- a/src/lepton_error.rs
+++ b/src/lepton_error.rs
@@ -11,7 +11,7 @@ use std::{fmt::Display, io::ErrorKind};
 #[non_exhaustive]
 /// Well-defined errors for bad things that are expected to happen as part of compression/decompression
 pub enum ExitCode {
-    //AssertionFailure = 1,
+    AssertionFailure = 1,
     //CodingError = 2,
     ShortRead = 3,
     Unsupported4Colors = 4,

--- a/src/lepton_error.rs
+++ b/src/lepton_error.rs
@@ -50,6 +50,14 @@ impl Display for ExitCode {
     }
 }
 
+impl ExitCode {
+    /// Converts the error code into a negative integer for use as an error code when
+    /// returning from a C API.
+    pub fn as_integer_error_code(self) -> i32 {
+        -(self as i32)
+    }
+}
+
 /// Standard error returned by Lepton library
 #[derive(Debug, Clone)]
 pub struct LeptonError {

--- a/src/lepton_error.rs
+++ b/src/lepton_error.rs
@@ -42,6 +42,7 @@ pub enum ExitCode {
     VerificationContentMismatch = 1005,
     SyntaxError = 1006,
     FileNotFound = 1007,
+    ExternalVerificationFailed = 1008,
 }
 
 impl Display for ExitCode {
@@ -51,10 +52,10 @@ impl Display for ExitCode {
 }
 
 impl ExitCode {
-    /// Converts the error code into a negative integer for use as an error code when
+    /// Converts the error code into an integer for use as an error code when
     /// returning from a C API.
     pub fn as_integer_error_code(self) -> i32 {
-        -(self as i32)
+        self as i32
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,6 +267,10 @@ pub unsafe extern "C" fn free_decompression_context(context: *mut std::ffi::c_vo
     // let Box destroy the object
 }
 
+/// partially decompresses an image from a Lepton file.
+///
+/// Returns -1 if more data is needed or if there is more data available, or 0 if done successfully.
+/// Returns > 0 if there is an error
 #[no_mangle]
 pub unsafe extern "C" fn decompress_image(
     context: *mut std::ffi::c_void,
@@ -297,7 +301,13 @@ pub unsafe extern "C" fn decompress_image(
         *result_size = writer.position().into();
         Ok(done)
     }) {
-        Ok(done) => done as i32,
+        Ok(done) => {
+            if done {
+                0
+            } else {
+                -1
+            }
+        }
         Err(e) => {
             copy_string(e.message(), error_string_buffer_len, error_string);
             e.exit_code().as_integer_error_code()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ pub mod lepton_error;
 
 use anyhow::Context;
 pub use enabled_features::EnabledFeatures;
-use helpers::{catch_unwind_result, copy_string, here};
+use helpers::{catch_unwind_result, copy_cstring_utf8_to_buffer, here};
 pub use lepton_error::{ExitCode, LeptonError};
 pub use metrics::Metrics;
 
@@ -309,7 +309,10 @@ pub unsafe extern "C" fn decompress_image(
             }
         }
         Err(e) => {
-            copy_string(e.message(), error_string_buffer_len, error_string);
+            copy_cstring_utf8_to_buffer(
+                e.message(),
+                std::slice::from_raw_parts_mut(error_string, error_string_buffer_len as usize),
+            );
             e.exit_code().as_integer_error_code()
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,11 @@ fn main_with_result() -> Result<(), LeptonError> {
             // the latest version of the encoder put these options in the header so we ignore this if the file specifies it
             ["-use32bitdc"] => enabled_features.use_16bit_dc_estimate = false,
             ["-use32bitadv"] => enabled_features.use_16bit_adv_predict = false,
+            ["-useleptonscalar"] => {
+                // default option is the vector version, since Lepton usually will get to compiled to at least SSE2
+                enabled_features.use_16bit_adv_predict = false;
+                enabled_features.use_16bit_dc_estimate = false;
+            }
             ["-overwrite"] => overwrite = true,
             ["-dump"] => dump = true,
             ["-all"] => all = true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
-use anyhow;
 use lepton_jpeg::metrics::CpuTimeMeasure;
 use lepton_jpeg::{
     decode_lepton, dump_jpeg, encode_lepton, encode_lepton_verify, EnabledFeatures, ExitCode,
@@ -16,6 +15,7 @@ use simple_logger::SimpleLogger;
 use thread_priority::{set_current_thread_priority, ThreadPriority, WinAPIThreadPriority};
 
 use std::fs::OpenOptions;
+use std::process::{Command, Stdio};
 use std::time::Instant;
 use std::{
     env,
@@ -24,14 +24,6 @@ use std::{
     time::Duration,
 };
 
-fn parse_numeric_parameter(arg: &str, name: &str) -> Option<i32> {
-    if arg.starts_with(name) {
-        Some(arg[name.len()..].parse::<i32>().unwrap())
-    } else {
-        None
-    }
-}
-
 #[derive(Copy, Clone, Debug)]
 enum FileType {
     Jpeg,
@@ -39,9 +31,10 @@ enum FileType {
 }
 
 // wrap main so that errors get printed nicely without a panic
-fn main_with_result() -> Result<(), anyhow::Error> {
+fn main_with_result() -> Result<(), LeptonError> {
     let args: Vec<String> = env::args().collect();
 
+    let mut verify_cpp = None;
     let mut filenames = Vec::new();
     let mut iterations = 1;
     let mut dump = false;
@@ -53,27 +46,29 @@ fn main_with_result() -> Result<(), anyhow::Error> {
     let mut filter_level = log::LevelFilter::Info;
 
     for i in 1..args.len() {
-        if args[i].starts_with("-") {
-            if let Some(x) = parse_numeric_parameter(args[i].as_str(), "-threads:") {
-                enabled_features.max_threads = x as u32;
-            } else if let Some(x) = parse_numeric_parameter(args[i].as_str(), "-iter:") {
-                iterations = x;
-            } else if let Some(x) = parse_numeric_parameter(args[i].as_str(), "-max-width:") {
-                enabled_features.max_jpeg_width = x;
-            } else if let Some(x) = parse_numeric_parameter(args[i].as_str(), "-max-height:") {
-                enabled_features.max_jpeg_height = x;
-            } else if args[i] == "-dump" {
-                dump = true;
-            } else if args[i] == "-all" {
-                all = true;
-            } else if args[i] == "-corrupt" {
+        match *args[i].split(':').collect::<Vec<&str>>().as_slice() {
+            ["-verifycpp", cpp] => verify_cpp = Some(cpp.to_string()),
+            ["-threads", threads] => enabled_features.max_threads = threads.parse::<u32>().unwrap(),
+            ["-iter", iter] => iterations = iter.parse::<i32>().unwrap(),
+            ["-max-width", width] => {
+                enabled_features.max_jpeg_width = width.parse::<i32>().unwrap()
+            }
+            ["-max-height", height] => {
+                enabled_features.max_jpeg_height = height.parse::<i32>().unwrap()
+            }
+            ["-dump"] => dump = true,
+            ["-all"] => all = true,
+            ["-corrupt"] => {
                 // randomly corrupt the files for testing
                 corrupt = true;
-            } else if args[i] == "-noverify" {
+            }
+            ["-noverify"] => {
                 verify = false;
-            } else if args[i] == "-quiet" {
+            }
+            ["-quiet"] => {
                 filter_level = log::LevelFilter::Warn;
-            } else if args[i] == "-version" {
+            }
+            ["-version"] => {
                 println!(
                     "compiled library Lepton version {}, git revision: {}",
                     env!("CARGO_PKG_VERSION"),
@@ -81,7 +76,8 @@ fn main_with_result() -> Result<(), anyhow::Error> {
                         args = ["--abbrev=40", "--always", "--dirty=-modified"]
                     )
                 );
-            } else if args[i] == "-highpriority" {
+            }
+            ["-highpriority"] => {
                 // used to force to run on p-cores, make sure this and
                 // any threadpool threads are set to the high priority
 
@@ -98,7 +94,8 @@ fn main_with_result() -> Result<(), anyhow::Error> {
                     .build_global()
                     .unwrap();
                 }
-            } else if args[i] == "-lowpriority" {
+            }
+            ["-lowpriority"] => {
                 // used to force to run on e-cores, make sure this and
                 // any threadpool threads are set to the high priority
 
@@ -115,31 +112,40 @@ fn main_with_result() -> Result<(), anyhow::Error> {
                     .build_global()
                     .unwrap();
                 }
-            } else if args[i] == "-overwrite" {
+            }
+            ["-overwrite"] => {
                 overwrite = true;
-            } else if args[i] == "-noprogressive" {
+            }
+            ["-noprogressive"] => {
                 enabled_features.progressive = false;
-            } else if args[i] == "-acceptdqtswithzeros" {
+            }
+            ["-acceptdqtswithzeros"] => {
                 enabled_features.reject_dqts_with_zeros = false;
-            } else if args[i] == "-use16bitdc" {
+            }
+            ["-use16bitdc"] => {
                 enabled_features.use_16bit_dc_estimate = true;
-            } else if args[i] == "-useleptonscalar" {
+            }
+            ["-useleptonscalar"] => {
                 // lepton files that were encoded by the dropbox c++ version compiled in scalar mode
                 enabled_features.use_16bit_adv_predict = false;
                 enabled_features.use_16bit_dc_estimate = false;
-            } else if args[i] == "-useleptonvector" {
+            }
+            ["-useleptonvector"] => {
                 // lepton files that were encoded by the dropbox c++ version compiled in AVX2/SSE2 mode
                 enabled_features.use_16bit_adv_predict = true;
                 enabled_features.use_16bit_dc_estimate = true;
-            } else {
-                return Err(LeptonError::new(
-                    ExitCode::SyntaxError,
-                    format!("unknown switch {0}", args[i]).as_str(),
-                )
-                .into());
             }
-        } else {
-            filenames.push(args[i].as_str());
+            _ => {
+                if args[i].starts_with("-") {
+                    return Err(LeptonError::new(
+                        ExitCode::SyntaxError,
+                        format!("unknown switch {0}", args[i]).as_str(),
+                    )
+                    .into());
+                } else {
+                    filenames.push(args[i].as_str());
+                }
+            }
         }
     }
 
@@ -269,13 +275,54 @@ fn main_with_result() -> Result<(), anyhow::Error> {
         std::io::stdout().write_all(&output_data[..])?
     } else {
         let output_file: String = filenames[1].to_owned();
+
+        let o = output_file.as_str();
         let mut fileout = OpenOptions::new()
             .write(true)
             .create(overwrite)
             .create_new(!overwrite)
-            .open(output_file.as_str())?;
+            .open(o)?;
 
-        fileout.write_all(&output_data[..])?
+        fileout.set_len(output_data.len() as u64)?;
+        fileout.write_all(&output_data[..])?;
+        drop(fileout);
+
+        // what we do is take the lepton output, and see if it recreates the input using the
+        // CPP version of the encoder/decoder
+        if let Some(v) = verify_cpp {
+            let (output, exit_code, stderr) = call_executable_with_input(v.as_str(), o)?;
+            if exit_code != 0 {
+                log::error!("cpp exit code: {}", exit_code);
+
+                return Err(LeptonError::new(
+                    ExitCode::ExternalVerificationFailed,
+                    format!(
+                        "verify failed with exit code {0} stderr: {1}",
+                        exit_code, stderr
+                    )
+                    .as_str(),
+                ))?;
+            }
+            if output[..].len() != input_data.len() {
+                return Err(LeptonError::new(
+                    ExitCode::ExternalVerificationFailed,
+                    format!(
+                        "verify failed with different length {0} != {1}",
+                        output[..].len(),
+                        input_data.len()
+                    )
+                    .as_str(),
+                ));
+            }
+            if output[..] != input_data[..] {
+                return Err(LeptonError::new(
+                    ExitCode::ExternalVerificationFailed,
+                    "verify failed with different data",
+                )
+                .into());
+            }
+            log::info!("verify succeeded with cpp version");
+        }
     }
 
     if iterations > 1 {
@@ -384,21 +431,57 @@ impl<W: Write + Seek> Write for VerifyWriter<W> {
 fn main() {
     match main_with_result() {
         Ok(_) => {}
-        Err(e) => match e.root_cause().downcast_ref::<LeptonError>() {
-            // try to extract the exit code if it was a well known error
-            Some(x) => {
-                eprintln!(
-                    "error code: {0} {1} {2}",
-                    x.exit_code(),
-                    x.exit_code() as i32,
-                    x.message()
-                );
-                std::process::exit(x.exit_code() as i32);
-            }
-            None => {
-                eprintln!("unknown error {0:?}", e);
-                std::process::exit(ExitCode::GeneralFailure as i32);
-            }
-        },
+        Err(e) => {
+            eprintln!(
+                "error code: {0} {1} {2}",
+                e.exit_code(),
+                e.exit_code().as_integer_error_code(),
+                e.message()
+            );
+            std::process::exit(e.exit_code().as_integer_error_code());
+        }
     }
+}
+
+pub fn call_executable_with_input(
+    executable: &str,
+    input_filename: &str,
+) -> Result<(Vec<u8>, i32, String), LeptonError> {
+    // temporary file to store the output of the cpp version so we can
+    // compare it with the rust version
+    let v = format!("{0}.verify", input_filename);
+    let verify_filename = v.as_str();
+
+    // delete if already exists
+    let _ = std::fs::remove_file(verify_filename);
+
+    log::info!(
+        "verifying input filename {} with {}",
+        input_filename,
+        executable
+    );
+
+    // Spawn the command
+    let child = Command::new(executable)
+        .arg(input_filename)
+        .arg(verify_filename)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()?;
+
+    // Wait for the child process to exit and collect output
+    let output = child.wait_with_output()?;
+
+    let mut file_in = File::open(verify_filename).unwrap();
+    let mut contents = Vec::new();
+    file_in.read_to_end(&mut contents).unwrap();
+
+    // remove the temporary file
+    let _ = std::fs::remove_file(verify_filename);
+
+    // Extract the stdout, stderr, and exit status
+    let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+    let exit_code = output.status.code().unwrap_or(-10000); // Handle the case where exit code is None
+
+    Ok((contents, exit_code, stderr))
 }

--- a/src/structs/lepton_file_reader.rs
+++ b/src/structs/lepton_file_reader.rs
@@ -672,7 +672,7 @@ fn parse_and_write_header() {
 }
 
 #[cfg(test)]
-fn read_file(filename: &str, ext: &str) -> Vec<u8> {
+pub fn read_file(filename: &str, ext: &str) -> Vec<u8> {
     use std::io::Read;
 
     let filename = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/src/structs/lepton_file_writer.rs
+++ b/src/structs/lepton_file_writer.rs
@@ -487,3 +487,40 @@ fn test_get_git_revision() {
 
     println!("{:x?}", lh.git_revision_prefix);
 }
+
+#[test]
+fn test_slrcity() {
+    test_file("slrcity")
+}
+
+#[cfg(test)]
+fn test_file(filename: &str) {
+    use crate::structs::lepton_file_reader::read_file;
+
+    let original = read_file(filename, ".jpg");
+
+    let mut enabled_features = EnabledFeatures::compat_lepton_vector_write();
+    enabled_features.max_threads = 2;
+
+    let mut output = Vec::new();
+
+    let _ = encode_lepton_wrapper(
+        &mut Cursor::new(&original),
+        &mut Cursor::new(&mut output),
+        &enabled_features,
+    )
+    .unwrap();
+
+    println!(
+        "Original size: {0}, compressed size: {1}",
+        original.len(),
+        output.len()
+    );
+
+    let mut recreate = Vec::new();
+
+    decode_lepton_file(&mut Cursor::new(&output), &mut recreate, &enabled_features).unwrap();
+
+    assert_eq!(original.len(), recreate.len());
+    assert!(original == recreate);
+}

--- a/src/structs/multiplexer.rs
+++ b/src/structs/multiplexer.rs
@@ -534,8 +534,13 @@ fn test_multiplex_read_panic() {
 fn test_multiplex_write_error() {
     let mut output = Vec::new();
 
-    let e: LeptonError = multiplex_write(&mut output, 10, |_, _| -> Result<usize> {
-        Err(LeptonError::new(ExitCode::FileNotFound, "test error"))?
+    let e: LeptonError = multiplex_write(&mut output, 10, |_, thread_id| -> Result<usize> {
+        if thread_id == 3 {
+            // have one thread fail
+            Err(LeptonError::new(ExitCode::FileNotFound, "test error"))?
+        } else {
+            Ok(0)
+        }
     })
     .unwrap_err()
     .into();
@@ -549,8 +554,11 @@ fn test_multiplex_write_error() {
 fn test_multiplex_write_panic() {
     let mut output = Vec::new();
 
-    let e: LeptonError = multiplex_write(&mut output, 10, |_, _| -> Result<usize> {
-        panic!();
+    let e: LeptonError = multiplex_write(&mut output, 10, |_, thread_id| -> Result<usize> {
+        if thread_id == 5 {
+            panic!();
+        }
+        Ok(0)
     })
     .unwrap_err()
     .into();

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -507,7 +507,7 @@ fn verify_extern_interface_rejects_compression_of_unsupported_jpegs(
             (&mut result_size) as *mut u64,
         );
 
-        assert_eq!(retval, file.1 as i32);
+        assert_eq!(retval, file.1.as_integer_error_code());
     }
 }
 

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -446,6 +446,8 @@ fn extern_interface_decompress_chunked() {
         let mut input_buffer = [0u8; 7];
         let mut output_buffer = [0u8; 13];
 
+        let mut error_string = [0u8; 1024];
+
         loop {
             let amount_read = file_read.read(&mut input_buffer).unwrap();
 
@@ -458,6 +460,8 @@ fn extern_interface_decompress_chunked() {
                 output_buffer.as_mut_ptr(),
                 output_buffer.len() as u64,
                 &mut result_size,
+                error_string.as_mut_ptr(),
+                error_string.len() as u64,
             );
 
             output.extend_from_slice(&output_buffer[..result_size as usize]);

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -467,8 +467,10 @@ fn extern_interface_decompress_chunked() {
             output.extend_from_slice(&output_buffer[..result_size as usize]);
 
             match result {
-                0 => {}
-                1 => {
+                -1 => {
+                    // need more data
+                }
+                0 => {
                     break;
                 }
                 _ => {


### PR DESCRIPTION
For calls across the ABI, ensure that we handle panics correctly and return a consistent error code that we can detect such problems. 

For the multiplexer, ensure that errors flow correctly across the thread boundary so we get the correct error back to the caller.