### PR TITLE
Make unary decoding faster (the most common case)

### DIFF
--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -364,7 +364,7 @@ fn test_roundtrip_vpxboolwriter_n_bits() {
 
 #[test]
 fn test_roundtrip_vpxboolwriter_unary() {
-    const MAX_UNARY: usize = 8;
+    const MAX_UNARY: usize = 20;
 
     #[derive(Default)]
     struct BranchData {


### PR DESCRIPTION
Since it's very rare to have more than 8 bits, make the unary decoding have a fix 8 iteration loop and the rest cold.