### PR TITLE
Remove index marker bytes handling

### DIFF
--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -670,7 +670,7 @@ fn roundtrip_large_coef() {
         &block,
         &block,
         [65535; 64],
-        0x2292c1567bcd03aa,
+        0xE54C911C5F2E4B56,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -295,11 +295,6 @@ impl<W: Write> VPXBoolWriter<W> {
             self.put_bit(false, &mut dummy_branch, ModelComponent::Dummy)?;
         }
 
-        // Ensure there's no ambigous collision with any index marker bytes
-        if (self.buffer.last().unwrap() & 0xe0) == 0xc0 {
-            self.buffer.push(0);
-        }
-
         self.writer.write_all(&self.buffer[..])?;
         Ok(())
     }


### PR DESCRIPTION
The code was a remnant of VPX video codec library used for Lepton development, see https://github.com/search?q=%22Ensure+there%27s+no+ambigous+collision+with+any+index+marker+bytes%22&type=code. As there are no marker bytes in Lepton encoded streams and decoding is not going further than actually encoded data, this additional byte is not necessary.