### PR TITLE
No count in stream reader

### DIFF
--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -670,7 +670,7 @@ fn roundtrip_large_coef() {
         &block,
         &block,
         [65535; 64],
-        0x2292c1567bcd03aa,
+        0xE54C911C5F2E4B56,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -163,10 +163,10 @@ impl<R: Read> VPXBoolReader<R> {
         let mut tmp_range = self.range;
 
         let mut decoded_so_far = 1;
-        // We can read only each 8-th iteration: minimum 56 bits are in `value` after `vpx_reader_fill`,
-        // and one `get` consumes at most 7 bits (with `range` coming from >127 to 1).
+        // We can read only each 7-th iteration: minimum 56 bits are in `value` after `vpx_reader_fill`,
+        // and one `get` needs 8 bits but consumes at most 7 bits (with `range` coming from >127 to 1).
         // As Lepton uses only 3 and 6 iterations, we can read only once.
-        debug_assert!(A <= 256);
+        debug_assert!(A <= 128);
         tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
 
         for _index in 0..A.ilog2() {
@@ -205,6 +205,7 @@ impl<R: Read> VPXBoolReader<R> {
             // and can have at least 7 iterations, so we can decode 7 bits at once.
             // Each iteration needs at least 8 bits of stream in `tmp_value` and
             // consumes max 7 of them.
+            debug_assert!(A <= 14);
             if value == 0 || value == 7 {
                 tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
             }

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -228,13 +228,13 @@ impl<R: Read> VPXBoolReader<R> {
                     self.model_statistics
                         .record_compression_stats(_cmp, 1, i64::from(shift));
                 }
-        
+
                 #[cfg(feature = "detailed_tracing")]
                 {
                     self.hash.hash(branches[value].get_u64());
                     self.hash.hash(tmp_value);
                     self.hash.hash(tmp_range);
-        
+
                     let hash = self.hash.get();
                     //if hash == 0x88f9c945
                     {
@@ -261,13 +261,13 @@ impl<R: Read> VPXBoolReader<R> {
                     self.model_statistics
                         .record_compression_stats(_cmp, 1, i64::from(shift));
                 }
-        
+
                 #[cfg(feature = "detailed_tracing")]
                 {
                     self.hash.hash(branches[value].get_u64());
                     self.hash.hash(tmp_value);
                     self.hash.hash(tmp_range);
-        
+
                     let hash = self.hash.get();
                     //if hash == 0x88f9c945
                     {

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -201,17 +201,17 @@ impl<R: Read> VPXBoolReader<R> {
         let mut split = mul_prob(tmp_range, branches[0].get_probability() as u64);
 
         debug_assert!(
-            A > 8,
+            A > 7,
             "we need at least 8 branches for unary encoding in order to be efficient"
         );
 
-        // We know that after this we can have at least 8 iterations,
-        // so we can decode 8 bits at once.
-        // In the extremely rare case that we have more than 8 bits,
+        // We know that after this we have min 56 stream bits in `tmp_value`,
+        // and can have at least 7 iterations, so we can decode 7 bits at once.
+        // In the extremely rare case that we have more than 7 bits,
         // we delegate to the cold version to avoid excessive inlining.
         tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
 
-        for value in 0..8 {
+        for value in 0..7 {
             if tmp_value >= split {
                 branches[value].record_and_update_bit(true);
 
@@ -296,10 +296,10 @@ impl<R: Read> VPXBoolReader<R> {
         mut tmp_range: u64,
         _cmp: ModelComponent,
     ) -> Result<usize> {
-        let mut value = 8;
-        // we can read once as in all use cases `A = 11` and we read maximum 3 bits more
+        let mut value = 7;
+        // we can read once as in all use cases `A = 11` and we read maximum 4 bits more
         debug_assert!(
-            A <= 16,
+            A <= 14,
             "with one additional read we can decode at most 8 bits"
         );
         tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -371,7 +371,7 @@ impl<R: Read> VPXBoolReader<R> {
     }
 
     // Fill `tmp_value` maximally still preserving space for the guard bit,
-    // after this returned value has `56 | shift` stream bits
+    // after this returned value has `56 | (63 - shift)` stream bits
     #[inline(always)]
     fn vpx_reader_fill(mut tmp_value: u64, upstream_reader: &mut R) -> Result<u64> {
         let mut shift: i32 = tmp_value.trailing_zeros() as i32;

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -31,6 +31,7 @@ use super::{branch::Branch, simple_hash::SimpleHash};
 const BITS_IN_BYTE: u32 = 8;
 const BITS_IN_VALUE: u32 = 64;
 const BITS_IN_VALUE_MINUS_LAST_BYTE: u32 = BITS_IN_VALUE - BITS_IN_BYTE;
+const VALUE_MASK: u64 = (1 << BITS_IN_VALUE_MINUS_LAST_BYTE) - 1;
 
 pub struct VPXBoolReader<R> {
     value: u64,
@@ -290,7 +291,7 @@ impl<R: Read> VPXBoolReader<R> {
             // this loop cannot be unrolled due to vaiable iterations number.
             // Moreover, this condition holds very rarely as `value` is usually already filled
             // by previous `get_bit` sign reading.
-            if tmp_value.trailing_zeros() >= BITS_IN_VALUE_MINUS_LAST_BYTE {
+            if tmp_value & VALUE_MASK == 0 {
                 tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
             }
 
@@ -312,7 +313,7 @@ impl<R: Read> VPXBoolReader<R> {
         // We use a set bit after the stream bits as a guard
         // and ensure that it never comes into the first byte,
         // thus not changing `get` comparison result `value >= split`.
-        if tmp_value.trailing_zeros() >= BITS_IN_VALUE_MINUS_LAST_BYTE {
+        if tmp_value & VALUE_MASK == 0 {
             tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
         }
 

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -290,6 +290,7 @@ impl<W: Write> VPXBoolWriter<W> {
     }
 
     pub fn finish(&mut self) -> Result<()> {
+        // push real stream bits out of `value`
         for _i in 0..32 {
             let mut dummy_branch = Branch::new();
             self.put_bit(false, &mut dummy_branch, ModelComponent::Dummy)?;
@@ -359,7 +360,7 @@ fn test_roundtrip_vpxboolwriter_n_bits() {
 
 #[test]
 fn test_roundtrip_vpxboolwriter_unary() {
-    const MAX_UNARY: usize = 14;
+    const MAX_UNARY: usize = 11; // the size used in Lepton
 
     #[derive(Default)]
     struct BranchData {

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -296,9 +296,9 @@ impl<W: Write> VPXBoolWriter<W> {
         }
 
         // Ensure there's no ambigous collision with any index marker bytes
-        if (self.buffer.last().unwrap() & 0xe0) == 0xc0 {
-            self.buffer.push(0);
-        }
+        // if (self.buffer.last().unwrap() & 0xe0) == 0xc0 {
+        //     self.buffer.push(0);
+        // }
 
         self.writer.write_all(&self.buffer[..])?;
         Ok(())

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -295,11 +295,6 @@ impl<W: Write> VPXBoolWriter<W> {
             self.put_bit(false, &mut dummy_branch, ModelComponent::Dummy)?;
         }
 
-        // Ensure there's no ambigous collision with any index marker bytes
-        // if (self.buffer.last().unwrap() & 0xe0) == 0xc0 {
-        //     self.buffer.push(0);
-        // }
-
         self.writer.write_all(&self.buffer[..])?;
         Ok(())
     }

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -364,7 +364,7 @@ fn test_roundtrip_vpxboolwriter_n_bits() {
 
 #[test]
 fn test_roundtrip_vpxboolwriter_unary() {
-    const MAX_UNARY: usize = 20;
+    const MAX_UNARY: usize = 14;
 
     #[derive(Default)]
     struct BranchData {

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -364,7 +364,7 @@ fn test_roundtrip_vpxboolwriter_n_bits() {
 
 #[test]
 fn test_roundtrip_vpxboolwriter_unary() {
-    const MAX_UNARY: usize = 8;
+    const MAX_UNARY: usize = 20;
 
     #[derive(Default)]
     struct BranchData {


### PR DESCRIPTION
This variant is even faster than https://github.com/microsoft/lepton_jpeg_rust/pull/105

This MR:
```
 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.lep images/img_52MP_7k.jpg':

       467 548 686      cache-references                                                        (41,80%)
        29 812 755      cache-misses                     #    6,38% of all cache refs           (41,64%)
     7 332 337 616      cycles                                                                  (41,44%)
       458 666 619      ic_fetch_stall.ic_stall_back_pressure                                        (41,41%)
       479 214 938      stalled-cycles-frontend          #    6,54% frontend cycles idle        (41,60%)
    16 315 488 306      instructions                     #    2,23  insn per cycle            
                                                  #    0,03  stalled cycles per insn     (41,89%)
     1 507 303 117      branch-instructions                                                     (41,96%)
        67 164 642      branch-misses                    #    4,46% of all branches             (42,12%)
     2 996 954 563      ic_fetch_stall.ic_stall_any                                             (42,48%)
        20 447 236      ic_fetch_stall.ic_stall_dq_empty                                        (42,55%)
        22 648 021      l2_cache_misses_from_ic_miss                                            (42,35%)
     1 047 781 384      l2_latency.l2_cycles_waiting_on_fills                                        (41,91%)
            98 962      faults                                                                
                 1      migrations                                                            

       1,659986131 seconds time elapsed

       1,458959000 seconds user
       0,179363000 seconds sys
```
MR https://github.com/microsoft/lepton_jpeg_rust/pull/105
```
 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.lep images/img_52MP_7k.jpg':

       462 618 667      cache-references                                                        (41,41%)
        23 228 616      cache-misses                     #    5,02% of all cache refs           (41,37%)
     7 494 953 579      cycles                                                                  (41,50%)
       463 724 832      ic_fetch_stall.ic_stall_back_pressure                                        (41,80%)
       514 969 223      stalled-cycles-frontend          #    6,87% frontend cycles idle        (42,09%)
    16 670 252 276      instructions                     #    2,22  insn per cycle            
                                                  #    0,03  stalled cycles per insn     (42,31%)
     1 471 222 439      branch-instructions                                                     (42,49%)
        64 093 640      branch-misses                    #    4,36% of all branches             (42,40%)
     3 116 460 630      ic_fetch_stall.ic_stall_any                                             (42,18%)
        18 174 744      ic_fetch_stall.ic_stall_dq_empty                                        (42,08%)
        15 815 293      l2_cache_misses_from_ic_miss                                            (41,81%)
     1 005 417 953      l2_latency.l2_cycles_waiting_on_fills                                        (41,57%)
            98 953      faults                                                                
                 1      migrations                                                            

       1,666129906 seconds time elapsed

       1,493631000 seconds user
       0,171957000 seconds sys
```
Base:
```
 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.lep images/img_52MP_7k.jpg':

       460 641 477      cache-references                                                        (41,22%)
        33 435 303      cache-misses                     #    7,26% of all cache refs           (41,60%)
     7 646 968 250      cycles                                                                  (41,74%)
       438 191 459      ic_fetch_stall.ic_stall_back_pressure                                        (41,95%)
       480 251 431      stalled-cycles-frontend          #    6,28% frontend cycles idle        (42,30%)
    17 679 981 487      instructions                     #    2,31  insn per cycle            
                                                  #    0,03  stalled cycles per insn     (42,47%)
     1 638 270 302      branch-instructions                                                     (42,34%)
        67 448 130      branch-misses                    #    4,12% of all branches             (42,34%)
     3 109 822 166      ic_fetch_stall.ic_stall_any                                             (42,09%)
        19 916 925      ic_fetch_stall.ic_stall_dq_empty                                        (41,96%)
        25 664 869      l2_cache_misses_from_ic_miss                                            (41,60%)
     1 007 007 390      l2_latency.l2_cycles_waiting_on_fills                                        (41,28%)
            98 966      faults                                                                
                 1      migrations                                                            

       1,706689238 seconds time elapsed

       1,509157000 seconds user
       0,197020000 seconds sys
```