### PR TITLE
Fix tests: exclude impossible random model states

### DIFF
--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -670,7 +670,7 @@ fn roundtrip_large_coef() {
         &block,
         &block,
         [65535; 64],
-        0x2292c1567bcd03aa,
+        0xE54C911C5F2E4B56,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -562,7 +562,7 @@ fn roundtrip_zeros() {
         &block,
         &block,
         [1; 64],
-        0xc2bc71721120de75,
+        0xD35CE4F07BEEAA3B,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
@@ -579,7 +579,7 @@ fn roundtrip_dc_only() {
         &block,
         &block,
         [1; 64],
-        0xe777404068ec50e0,
+        0x3F8ED27DE13533D,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
@@ -599,7 +599,7 @@ fn roundtrip_edges_only() {
         &block,
         &block,
         [1; 64],
-        0xe3f7a94ebde1a7a,
+        0xCC68BE8F2B8638AE,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
@@ -623,7 +623,7 @@ fn roundtrip_ac_only() {
         &block,
         &block,
         [1; 64],
-        0x2a9b90a785c01dc1,
+        0xD1656611371816F9,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
@@ -638,7 +638,7 @@ fn roundtrip_ones() {
         &block,
         &block,
         [1; 64],
-        0xf665236641c3940b,
+        0x5204BE68761A40EB,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
@@ -656,7 +656,7 @@ fn roundtrip_large_coef() {
         &block,
         &block,
         [1; 64],
-        0x7b5080d88472e2bb,
+        0x49A1AC82D7FF9DBE,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 
@@ -670,7 +670,7 @@ fn roundtrip_large_coef() {
         &block,
         &block,
         [65535; 64],
-        0xE54C911C5F2E4B56,
+        0x95AB6F40A8D52322,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
@@ -700,7 +700,7 @@ fn roundtrip_random_seed() {
         &above_left,
         &here,
         qt,
-        0xb29a6ba0fe9f14e6,
+        0x2251A81E41EF0118,
         &EnabledFeatures::compat_lepton_scalar_read(),
     );
 
@@ -711,7 +711,7 @@ fn roundtrip_random_seed() {
         &above_left,
         &here,
         qt,
-        0x12aa8dc3af82fc8,
+        0x62FD1F1BE6787FFF,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 
@@ -737,7 +737,7 @@ fn roundtrip_unique() {
         &above_left,
         &here,
         [1; 64],
-        0xaa01fa1a67ba3a1,
+        0x33705FECAA1DBEEA,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
@@ -765,7 +765,7 @@ fn roundtrip_non_zeros_counts() {
         &block,
         &block,
         [1; 64],
-        0x57482d106b5c83b6,
+        0x4369094AE45044F4,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
@@ -782,7 +782,7 @@ fn make_random_model() -> Box<Model> {
     let mut rng = crate::helpers::get_rand_from_seed([2u8; 32]);
 
     model.walk(|x| {
-        x.set_count(rng.gen_range(0x101..=0xffff));
+        x.set_count(rng.gen_range(0x01..=0xfe) * 256 + rng.gen_range(0x01..=0xfe));
     });
     model
 }

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -163,10 +163,10 @@ impl<R: Read> VPXBoolReader<R> {
         let mut tmp_range = self.range;
 
         let mut decoded_so_far = 1;
-        // We can read only each 8-th iteration: minimum 56 bits are in `value` after `vpx_reader_fill`,
-        // and one `get` consumes at most 7 bits (with `range` coming from >127 to 1).
+        // We can read only each 7-th iteration: minimum 56 bits are in `value` after `vpx_reader_fill`,
+        // and one `get` needs 8 bits but consumes at most 7 bits (with `range` coming from >127 to 1).
         // As Lepton uses only 3 and 6 iterations, we can read only once.
-        debug_assert!(A <= 256);
+        debug_assert!(A <= 128);
         tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
 
         for _index in 0..A.ilog2() {
@@ -205,6 +205,7 @@ impl<R: Read> VPXBoolReader<R> {
             // and can have at least 7 iterations, so we can decode 7 bits at once.
             // Each iteration needs at least 8 bits of stream in `tmp_value` and
             // consumes max 7 of them.
+            debug_assert!(A <= 14);
             if value == 0 || value == 7 {
                 tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
             }

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -228,13 +228,13 @@ impl<R: Read> VPXBoolReader<R> {
                     self.model_statistics
                         .record_compression_stats(_cmp, 1, i64::from(shift));
                 }
-        
+
                 #[cfg(feature = "detailed_tracing")]
                 {
                     self.hash.hash(branches[value].get_u64());
                     self.hash.hash(tmp_value);
                     self.hash.hash(tmp_range);
-        
+
                     let hash = self.hash.get();
                     //if hash == 0x88f9c945
                     {
@@ -261,13 +261,13 @@ impl<R: Read> VPXBoolReader<R> {
                     self.model_statistics
                         .record_compression_stats(_cmp, 1, i64::from(shift));
                 }
-        
+
                 #[cfg(feature = "detailed_tracing")]
                 {
                     self.hash.hash(branches[value].get_u64());
                     self.hash.hash(tmp_value);
                     self.hash.hash(tmp_range);
-        
+
                     let hash = self.hash.get();
                     //if hash == 0x88f9c945
                     {

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -201,17 +201,17 @@ impl<R: Read> VPXBoolReader<R> {
         let mut split = mul_prob(tmp_range, branches[0].get_probability() as u64);
 
         debug_assert!(
-            A > 8,
+            A > 7,
             "we need at least 8 branches for unary encoding in order to be efficient"
         );
 
-        // We know that after this we can have at least 8 iterations,
-        // so we can decode 8 bits at once.
-        // In the extremely rare case that we have more than 8 bits,
+        // We know that after this we have min 56 stream bits in `tmp_value`,
+        // and can have at least 7 iterations, so we can decode 7 bits at once.
+        // In the extremely rare case that we have more than 7 bits,
         // we delegate to the cold version to avoid excessive inlining.
         tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
 
-        for value in 0..8 {
+        for value in 0..7 {
             if tmp_value >= split {
                 branches[value].record_and_update_bit(true);
 
@@ -296,10 +296,10 @@ impl<R: Read> VPXBoolReader<R> {
         mut tmp_range: u64,
         _cmp: ModelComponent,
     ) -> Result<usize> {
-        let mut value = 8;
-        // we can read once as in all use cases `A = 11` and we read maximum 3 bits more
+        let mut value = 7;
+        // we can read once as in all use cases `A = 11` and we read maximum 4 bits more
         debug_assert!(
-            A <= 16,
+            A <= 14,
             "with one additional read we can decode at most 8 bits"
         );
         tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -371,7 +371,7 @@ impl<R: Read> VPXBoolReader<R> {
     }
 
     // Fill `tmp_value` maximally still preserving space for the guard bit,
-    // after this returned value has `56 | shift` stream bits
+    // after this returned value has `56 | (63 - shift)` stream bits
     #[inline(always)]
     fn vpx_reader_fill(mut tmp_value: u64, upstream_reader: &mut R) -> Result<u64> {
         let mut shift: i32 = tmp_value.trailing_zeros() as i32;

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -31,6 +31,7 @@ use super::{branch::Branch, simple_hash::SimpleHash};
 const BITS_IN_BYTE: u32 = 8;
 const BITS_IN_VALUE: u32 = 64;
 const BITS_IN_VALUE_MINUS_LAST_BYTE: u32 = BITS_IN_VALUE - BITS_IN_BYTE;
+const VALUE_MASK: u64 = (1 << BITS_IN_VALUE_MINUS_LAST_BYTE) - 1;
 
 pub struct VPXBoolReader<R> {
     value: u64,
@@ -290,7 +291,7 @@ impl<R: Read> VPXBoolReader<R> {
             // this loop cannot be unrolled due to vaiable iterations number.
             // Moreover, this condition holds very rarely as `value` is usually already filled
             // by previous `get_bit` sign reading.
-            if tmp_value.trailing_zeros() >= BITS_IN_VALUE_MINUS_LAST_BYTE {
+            if tmp_value & VALUE_MASK == 0 {
                 tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
             }
 
@@ -312,7 +313,7 @@ impl<R: Read> VPXBoolReader<R> {
         // We use a set bit after the stream bits as a guard
         // and ensure that it never comes into the first byte,
         // thus not changing `get` comparison result `value >= split`.
-        if tmp_value.trailing_zeros() >= BITS_IN_VALUE_MINUS_LAST_BYTE {
+        if tmp_value & VALUE_MASK == 0 {
             tmp_value = Self::vpx_reader_fill(tmp_value, &mut self.upstream_reader)?;
         }
 

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -290,6 +290,7 @@ impl<W: Write> VPXBoolWriter<W> {
     }
 
     pub fn finish(&mut self) -> Result<()> {
+        // push real stream bits out of `value`
         for _i in 0..32 {
             let mut dummy_branch = Branch::new();
             self.put_bit(false, &mut dummy_branch, ModelComponent::Dummy)?;
@@ -359,7 +360,7 @@ fn test_roundtrip_vpxboolwriter_n_bits() {
 
 #[test]
 fn test_roundtrip_vpxboolwriter_unary() {
-    const MAX_UNARY: usize = 14;
+    const MAX_UNARY: usize = 11; // the size used in Lepton
 
     #[derive(Default)]
     struct BranchData {

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -296,9 +296,9 @@ impl<W: Write> VPXBoolWriter<W> {
         }
 
         // Ensure there's no ambigous collision with any index marker bytes
-        if (self.buffer.last().unwrap() & 0xe0) == 0xc0 {
-            self.buffer.push(0);
-        }
+        // if (self.buffer.last().unwrap() & 0xe0) == 0xc0 {
+        //     self.buffer.push(0);
+        // }
 
         self.writer.write_all(&self.buffer[..])?;
         Ok(())

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -295,11 +295,6 @@ impl<W: Write> VPXBoolWriter<W> {
             self.put_bit(false, &mut dummy_branch, ModelComponent::Dummy)?;
         }
 
-        // Ensure there's no ambigous collision with any index marker bytes
-        // if (self.buffer.last().unwrap() & 0xe0) == 0xc0 {
-        //     self.buffer.push(0);
-        // }
-
         self.writer.write_all(&self.buffer[..])?;
         Ok(())
     }

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -364,7 +364,7 @@ fn test_roundtrip_vpxboolwriter_n_bits() {
 
 #[test]
 fn test_roundtrip_vpxboolwriter_unary() {
-    const MAX_UNARY: usize = 20;
+    const MAX_UNARY: usize = 14;
 
     #[derive(Default)]
     struct BranchData {

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -364,7 +364,7 @@ fn test_roundtrip_vpxboolwriter_n_bits() {
 
 #[test]
 fn test_roundtrip_vpxboolwriter_unary() {
-    const MAX_UNARY: usize = 8;
+    const MAX_UNARY: usize = 20;
 
     #[derive(Default)]
     struct BranchData {


### PR DESCRIPTION
Fix tests: exclude impossible random model states with 0 in true or false counters