### PR TITLE
Remove intermediate anyhow usage and just rely on LeptonError for returning errors 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,15 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
-dependencies = [
- "gimli",
-]
-
-[[package]]
 name = "adler2"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,34 +18,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86fdf8605db99b54d3cd748a44c6d04df638eb5dafb219b135d0149bd0db01f6"
-dependencies = [
- "backtrace",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "backtrace"
-version = "0.3.74"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
-dependencies = [
- "addr2line",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "bitflags"
@@ -286,12 +253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gimli"
-version = "0.31.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
-
-[[package]]
 name = "git-version"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,7 +310,6 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 name = "lepton_jpeg"
 version = "0.4.0"
 dependencies = [
- "anyhow",
  "bytemuck",
  "byteorder",
  "cpu-time",
@@ -408,15 +368,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "object"
-version = "0.36.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -577,12 +528,6 @@ dependencies = [
  "syn 2.0.79",
  "unicode-ident",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -807,7 +752,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -816,29 +761,13 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -848,22 +777,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -872,28 +789,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -902,34 +801,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ bytemuck = "1"
 byteorder = "1.4"
 flate2 = "1.0"
 default-boxed = "0.2"
-anyhow = { version="1.0", features = ["backtrace"]}
 wide = "0.7"
 log = "0.4"
 simple_logger ="5.0"

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -8,17 +8,9 @@ use std::panic::{catch_unwind, AssertUnwindSafe};
 
 use crate::lepton_error::{ExitCode, LeptonError};
 
-macro_rules! here {
-    () => {
-        concat!("at ", file!(), " line ", line!())
-    };
-}
-
-pub(crate) use here;
-
 /// Helper function to catch panics and convert them into the appropriate LeptonError
 pub fn catch_unwind_result<R>(
-    f: impl FnOnce() -> Result<R, anyhow::Error>,
+    f: impl FnOnce() -> Result<R, LeptonError>,
 ) -> Result<R, LeptonError> {
     match catch_unwind(AssertUnwindSafe(f)) {
         Ok(r) => r.map_err(|e| e.into()),
@@ -83,11 +75,6 @@ pub const fn u16_bit_length(v: u16) -> u8 {
 #[inline(always)]
 pub const fn u32_bit_length(v: u32) -> u8 {
     return 32 - v.leading_zeros() as u8;
-}
-
-#[cold]
-pub fn err_exit_code<T>(error_code: ExitCode, message: &str) -> anyhow::Result<T> {
-    return Err(anyhow::Error::new(LeptonError::new(error_code, message)));
 }
 
 pub fn buffer_prefix_matches_marker<const BS: usize, const MS: usize>(

--- a/src/lepton_error.rs
+++ b/src/lepton_error.rs
@@ -34,6 +34,7 @@ pub enum ExitCode {
     InvalidPadding = 45,
     //WrapperOutputWriteFailed = 101,
     BadLeptonFile = 102,
+    ChannelFailure = 103,
 
     // Add new failures here
     GeneralFailure = 1000,
@@ -101,10 +102,12 @@ impl LeptonError {
     }
 
     #[cold]
+    #[inline(never)]
+    #[track_caller]
     pub fn add_context(&mut self) {
         self.i
             .message
-            .push_str(&format!(" at {}", std::panic::Location::caller()));
+            .push_str(&format!("\n at {}", std::panic::Location::caller()));
     }
 }
 
@@ -157,7 +160,7 @@ impl From<TryFromIntError> for LeptonError {
 impl<T> From<std::sync::mpsc::SendError<T>> for LeptonError {
     #[track_caller]
     fn from(e: std::sync::mpsc::SendError<T>) -> Self {
-        let mut e = LeptonError::new(ExitCode::GeneralFailure, e.to_string().as_str());
+        let mut e = LeptonError::new(ExitCode::ChannelFailure, e.to_string().as_str());
         e.add_context();
         e
     }
@@ -165,7 +168,7 @@ impl<T> From<std::sync::mpsc::SendError<T>> for LeptonError {
 impl From<std::sync::mpsc::RecvError> for LeptonError {
     #[track_caller]
     fn from(e: std::sync::mpsc::RecvError) -> Self {
-        let mut e = LeptonError::new(ExitCode::GeneralFailure, e.to_string().as_str());
+        let mut e = LeptonError::new(ExitCode::ChannelFailure, e.to_string().as_str());
         e.add_context();
         e
     }

--- a/src/lepton_error.rs
+++ b/src/lepton_error.rs
@@ -4,7 +4,9 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
-use std::{fmt::Display, io::ErrorKind};
+use std::fmt::Display;
+use std::io::ErrorKind;
+use std::num::TryFromIntError;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(dead_code)]
@@ -59,88 +61,113 @@ impl ExitCode {
     }
 }
 
-/// Standard error returned by Lepton library
+/// Since errors are rare and stop everything, we want them to be as lightweight as possible.
 #[derive(Debug, Clone)]
-pub struct LeptonError {
-    /// standard error code
+struct LeptonErrorInternal {
     exit_code: ExitCode,
-
-    /// diagnostic message including location. Content should not be relied on.
     message: String,
 }
 
+/// Standard error returned by Lepton library
+#[derive(Debug, Clone)]
+pub struct LeptonError {
+    i: Box<LeptonErrorInternal>,
+}
+
+pub type Result<T> = std::result::Result<T, LeptonError>;
+
 impl Display for LeptonError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{0}: {1}", self.exit_code, self.message)
+        write!(f, "{0}: {1}", self.i.exit_code, self.i.message)
     }
 }
 
 impl LeptonError {
     pub fn new(exit_code: ExitCode, message: &str) -> LeptonError {
         LeptonError {
-            exit_code,
-            message: message.to_owned(),
+            i: Box::new(LeptonErrorInternal {
+                exit_code,
+                message: message.to_owned(),
+            }),
         }
     }
 
     pub fn exit_code(&self) -> ExitCode {
-        self.exit_code
+        self.i.exit_code
     }
 
     pub fn message(&self) -> &str {
-        &self.message
+        &self.i.message
+    }
+
+    #[cold]
+    pub fn add_context(&mut self) {
+        self.i
+            .message
+            .push_str(&format!(" at {}", std::panic::Location::caller()));
+    }
+}
+
+#[cold]
+#[track_caller]
+pub fn err_exit_code<T>(error_code: ExitCode, message: &str) -> Result<T> {
+    let mut e = LeptonError::new(error_code, message);
+    e.add_context();
+    return Err(e);
+}
+
+pub trait AddContext<T> {
+    #[track_caller]
+    fn context(self) -> Result<T>;
+}
+
+impl<T, E: Into<LeptonError>> AddContext<T> for core::result::Result<T, E> {
+    #[track_caller]
+    fn context(self) -> Result<T> {
+        match self {
+            Ok(x) => Ok(x),
+            Err(e) => {
+                let mut e = e.into();
+                e.add_context();
+                Err(e)
+            }
+        }
     }
 }
 
 impl std::error::Error for LeptonError {}
-
-impl From<anyhow::Error> for LeptonError {
-    fn from(mut error: anyhow::Error) -> Self {
-        // first see if there is a LeptonError already inside
-        match error.downcast::<LeptonError>() {
-            Ok(le) => {
-                return le;
-            }
-            Err(old_error) => {
-                error = old_error;
-            }
-        }
-
-        // capture the original error string before we lose it due
-        // to downcasting to look for stashed LeptonErrors
-        let original_string = error.to_string();
-
-        // see if there is a LeptonError hiding inside an io error
-        // which happens if we cross an API boundary that returns an std::io:Error
-        // like Read or Write
-        match error.downcast::<std::io::Error>() {
-            Ok(ioe) => match ioe.downcast::<LeptonError>() {
-                Ok(le) => {
-                    return le;
-                }
-                Err(e) => {
-                    return LeptonError {
-                        exit_code: get_io_error_exit_code(&e),
-                        message: format!("{} {}", e, original_string),
-                    };
-                }
-            },
-            Err(_) => {}
-        }
-
-        // don't know what we got, so treat it as a general failure
-        return LeptonError {
-            exit_code: ExitCode::GeneralFailure,
-            message: original_string,
-        };
-    }
-}
 
 fn get_io_error_exit_code(e: &std::io::Error) -> ExitCode {
     if e.kind() == ErrorKind::UnexpectedEof {
         ExitCode::ShortRead
     } else {
         ExitCode::OsError
+    }
+}
+
+impl From<TryFromIntError> for LeptonError {
+    #[track_caller]
+    fn from(e: TryFromIntError) -> Self {
+        let mut e = LeptonError::new(ExitCode::GeneralFailure, e.to_string().as_str());
+        e.add_context();
+        e
+    }
+}
+
+impl<T> From<std::sync::mpsc::SendError<T>> for LeptonError {
+    #[track_caller]
+    fn from(e: std::sync::mpsc::SendError<T>) -> Self {
+        let mut e = LeptonError::new(ExitCode::GeneralFailure, e.to_string().as_str());
+        e.add_context();
+        e
+    }
+}
+impl From<std::sync::mpsc::RecvError> for LeptonError {
+    #[track_caller]
+    fn from(e: std::sync::mpsc::RecvError) -> Self {
+        let mut e = LeptonError::new(ExitCode::GeneralFailure, e.to_string().as_str());
+        e.add_context();
+        e
     }
 }
 
@@ -153,11 +180,9 @@ impl From<std::io::Error> for LeptonError {
                 return le;
             }
             Err(e) => {
-                let caller = std::panic::Location::caller();
-                return LeptonError {
-                    exit_code: get_io_error_exit_code(&e),
-                    message: format!("error {} at {}", e.to_string(), caller.to_string()),
-                };
+                let mut e = LeptonError::new(get_io_error_exit_code(&e), e.to_string().as_str());
+                e.add_context();
+                e
             }
         }
     }
@@ -173,24 +198,15 @@ impl From<LeptonError> for std::io::Error {
 #[test]
 fn test_error_translation() {
     // test wrapping inside an io error
-    fn my_std_error() -> Result<(), std::io::Error> {
+    fn my_std_error() -> core::result::Result<(), std::io::Error> {
         Err(LeptonError::new(ExitCode::SyntaxError, "test error").into())
     }
 
     let e: LeptonError = my_std_error().unwrap_err().into();
-    assert_eq!(e.exit_code, ExitCode::SyntaxError);
-    assert_eq!(e.message, "test error");
-
-    // wrapping inside anyhow
-    fn my_anyhow() -> Result<(), anyhow::Error> {
-        Err(LeptonError::new(ExitCode::SyntaxError, "test error").into())
-    }
-
-    let e: LeptonError = my_anyhow().unwrap_err().into();
-    assert_eq!(e.exit_code, ExitCode::SyntaxError);
-    assert_eq!(e.message, "test error");
+    assert_eq!(e.exit_code(), ExitCode::SyntaxError);
+    assert_eq!(e.message(), "test error");
 
     // an IO error should be translated into an OsError
     let e: LeptonError = std::io::Error::new(std::io::ErrorKind::NotFound, "file not found").into();
-    assert_eq!(e.exit_code, ExitCode::OsError);
+    assert_eq!(e.exit_code(), ExitCode::OsError);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,7 @@ pub unsafe extern "C" fn WrapperDecompressImageEx(
             return 0;
         }
         Err(e) => {
+            println!("Error: {:?}", e);
             return e.exit_code().as_integer_error_code();
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,6 @@ pub fn decode_lepton<R: BufRead, W: Write>(
     enabled_features: &EnabledFeatures,
 ) -> Result<Metrics> {
     structs::lepton_file_reader::decode_lepton_file(reader, writer, enabled_features)
-        .map_err(LeptonError::from)
 }
 
 /// Encodes JPEG as compressed Lepton format.
@@ -39,7 +38,6 @@ pub fn encode_lepton<R: BufRead + Seek, W: Write + Seek>(
     enabled_features: &EnabledFeatures,
 ) -> Result<Metrics> {
     structs::lepton_file_writer::encode_lepton_wrapper(reader, writer, enabled_features)
-        .map_err(LeptonError::from)
 }
 
 /// Compresses JPEG into Lepton format and compares input to output to verify that compression roundtrip is OK
@@ -48,7 +46,6 @@ pub fn encode_lepton_verify(
     enabled_features: &EnabledFeatures,
 ) -> Result<(Vec<u8>, Metrics)> {
     structs::lepton_file_writer::encode_lepton_wrapper_verify(input_data, enabled_features)
-        .map_err(LeptonError::from)
 }
 
 /// C ABI interface for compressing image, exposed from DLL
@@ -180,7 +177,6 @@ pub unsafe extern "C" fn WrapperDecompressImageEx(
             return 0;
         }
         Err(e) => {
-            println!("Error: {:?}", e);
             return e.exit_code().as_integer_error_code();
         }
     }
@@ -243,7 +239,6 @@ impl LeptonFileReaderContext {
     ) -> Result<bool> {
         self.reader
             .process_buffer(input, input_complete, writer, output_buffer_size)
-            .map_err(LeptonError::from)
     }
 }
 
@@ -334,8 +329,7 @@ pub fn dump_jpeg(input_data: &[u8], all: bool, enabled_features: &EnabledFeature
             println!("parsed header:");
             let s = format!("{jh:?}");
             println!("{0}", s.replace("},", "},\r\n").replace("],", "],\r\n"));
-        })
-        .map_err(LeptonError::from)?;
+        })?;
     } else {
         let mut reader = Cursor::new(input_data);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,12 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
+use std::env;
+use std::fs::{File, OpenOptions};
+use std::io::{stdin, stdout, Cursor, IsTerminal, Read, Seek, Write};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
 use lepton_jpeg::metrics::CpuTimeMeasure;
 use lepton_jpeg::{
     decode_lepton, dump_jpeg, encode_lepton, encode_lepton_verify, EnabledFeatures, ExitCode,
@@ -13,16 +19,6 @@ use log::{error, info};
 use simple_logger::SimpleLogger;
 #[cfg(all(target_os = "windows", feature = "use_rayon"))]
 use thread_priority::{set_current_thread_priority, ThreadPriority, WinAPIThreadPriority};
-
-use std::fs::OpenOptions;
-use std::process::{Command, Stdio};
-use std::time::Instant;
-use std::{
-    env,
-    fs::File,
-    io::{stdin, stdout, Cursor, IsTerminal, Read, Seek, Write},
-    time::Duration,
-};
 
 #[derive(Copy, Clone, Debug)]
 enum FileType {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,5 @@
-use std::{collections::HashMap, time::Duration};
+use std::collections::HashMap;
+use std::time::Duration;
 
 #[cfg(windows)]
 use cpu_time::ThreadTime;

--- a/src/structs/bit_reader.rs
+++ b/src/structs/bit_reader.rs
@@ -6,10 +6,8 @@
 
 use std::io::Read;
 
-use crate::LeptonError;
-use crate::{helpers::err_exit_code, jpeg_code};
-
-use crate::lepton_error::ExitCode;
+use crate::lepton_error::{err_exit_code, ExitCode};
+use crate::{jpeg_code, LeptonError};
 
 // Implemenation of bit reader on top of JPEG data stream as read by a reader
 pub struct BitReader<R> {
@@ -176,7 +174,10 @@ impl<R: Read> BitReader<R> {
 
     /// used to verify whether this image is using 1s or 0s as fill bits.
     /// Returns whether the fill bit was 1 or so or unknown (None)
-    pub fn read_and_verify_fill_bits(&mut self, pad_bit: &mut Option<u8>) -> anyhow::Result<()> {
+    pub fn read_and_verify_fill_bits(
+        &mut self,
+        pad_bit: &mut Option<u8>,
+    ) -> Result<(), LeptonError> {
         // if there are bits left, we need to see whether they
         // are 1s or zeros.
 
@@ -215,7 +216,7 @@ impl<R: Read> BitReader<R> {
         return Ok(());
     }
 
-    pub fn verify_reset_code(&mut self) -> anyhow::Result<()> {
+    pub fn verify_reset_code(&mut self) -> Result<(), LeptonError> {
         // we reached the end of a MCU, so we need to find a reset code and the huffman codes start get padded out, but the spec
         // doesn't specify whether the padding should be 1s or 0s, so we ensure that at least the file is consistant so that we
         // can recode it again just by remembering the pad bit.

--- a/src/structs/bit_writer.rs
+++ b/src/structs/bit_writer.rs
@@ -140,11 +140,12 @@ impl BitWriter {
 }
 
 #[cfg(test)]
-use super::bit_reader::BitReader;
+use std::io::Cursor;
+
 #[cfg(test)]
 use crate::helpers::u32_bit_length;
 #[cfg(test)]
-use std::io::Cursor;
+use crate::structs::bit_reader::BitReader;
 
 // write a test pattern with an escape and see if it matches
 #[test]

--- a/src/structs/block_based_image.rs
+++ b/src/structs/block_based_image.rs
@@ -6,13 +6,12 @@
 
 use bytemuck::{cast, cast_ref};
 use log::info;
+use unroll::unroll_for_loops;
 use wide::i16x8;
 
 use crate::consts::ZIGZAG_TO_TRANSPOSED;
-
-use super::{block_context::BlockContext, jpeg_header::JPegHeader};
-
-use unroll::unroll_for_loops;
+use crate::structs::block_context::BlockContext;
+use crate::structs::jpeg_header::JPegHeader;
 
 /// holds the 8x8 blocks for a given component. Since we do multithreaded encoding,
 /// the image may only hold a subset of the components (specified by dpos_offset),

--- a/src/structs/block_context.rs
+++ b/src/structs/block_context.rs
@@ -4,9 +4,9 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
-use super::block_based_image::{AlignedBlock, BlockBasedImage, EMPTY_BLOCK};
-use super::neighbor_summary::{NeighborSummary, NEIGHBOR_DATA_EMPTY};
-use super::probability_tables::ProbabilityTables;
+use crate::structs::block_based_image::{AlignedBlock, BlockBasedImage, EMPTY_BLOCK};
+use crate::structs::neighbor_summary::{NeighborSummary, NEIGHBOR_DATA_EMPTY};
+use crate::structs::probability_tables::ProbabilityTables;
 
 pub struct BlockContext {
     cur_block_index: i32,

--- a/src/structs/block_context.rs
+++ b/src/structs/block_context.rs
@@ -7,7 +7,6 @@
 use crate::structs::block_based_image::{AlignedBlock, BlockBasedImage, EMPTY_BLOCK};
 use crate::structs::neighbor_summary::{NeighborSummary, NEIGHBOR_DATA_EMPTY};
 use crate::structs::probability_tables::ProbabilityTables;
-
 pub struct BlockContext {
     cur_block_index: i32,
     above_block_index: i32,

--- a/src/structs/idct.rs
+++ b/src/structs/idct.rs
@@ -7,7 +7,7 @@
 use bytemuck::cast;
 use wide::{i16x8, i32x8};
 
-use super::block_based_image::AlignedBlock;
+use crate::structs::block_based_image::AlignedBlock;
 
 const _W1: i32 = 2841; // 2048*sqrt(2)*cos(1*pi/16)
 const _W2: i32 = 2676; // 2048*sqrt(2)*cos(2*pi/16)

--- a/src/structs/jpeg_read.rs
+++ b/src/structs/jpeg_read.rs
@@ -37,6 +37,7 @@ use std::io::Read;
 
 use crate::consts::*;
 use crate::helpers::*;
+use crate::lepton_error::Result;
 use crate::lepton_error::{err_exit_code, AddContext, ExitCode};
 use crate::structs::bit_reader::BitReader;
 use crate::structs::block_based_image::{AlignedBlock, BlockBasedImage};
@@ -44,8 +45,6 @@ use crate::structs::jpeg_header::HuffTree;
 use crate::structs::jpeg_position_state::JpegPositionState;
 use crate::structs::lepton_header::LeptonHeader;
 use crate::structs::thread_handoff::ThreadHandoff;
-use crate::lepton_error::Result;
-
 
 pub fn read_scan<R: Read>(
     lp: &mut LeptonHeader,

--- a/src/structs/jpeg_read.rs
+++ b/src/structs/jpeg_read.rs
@@ -32,23 +32,20 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-use anyhow::{Context, Result};
 use std::cmp::{self, max};
 use std::io::Read;
 
-use crate::helpers::here;
-
-use super::bit_reader::BitReader;
-use super::block_based_image::{AlignedBlock, BlockBasedImage};
-use super::jpeg_position_state::JpegPositionState;
-use super::lepton_header::LeptonHeader;
-use super::thread_handoff::ThreadHandoff;
-use crate::lepton_error::ExitCode;
-
 use crate::consts::*;
 use crate::helpers::*;
+use crate::lepton_error::{err_exit_code, AddContext, ExitCode};
+use crate::structs::bit_reader::BitReader;
+use crate::structs::block_based_image::{AlignedBlock, BlockBasedImage};
+use crate::structs::jpeg_header::HuffTree;
+use crate::structs::jpeg_position_state::JpegPositionState;
+use crate::structs::lepton_header::LeptonHeader;
+use crate::structs::thread_handoff::ThreadHandoff;
+use crate::lepton_error::Result;
 
-use super::jpeg_header::HuffTree;
 
 pub fn read_scan<R: Read>(
     lp: &mut LeptonHeader,
@@ -80,10 +77,10 @@ pub fn read_scan<R: Read>(
                 image_data,
                 &mut do_handoff,
             )
-            .context(here!())?;
+            .context()?;
         } else if jf.cs_to == 0 && jf.cs_sah == 0 {
             // only need DC
-            jf.verify_huffman_table(true, false).context(here!())?;
+            jf.verify_huffman_table(true, false).context()?;
 
             let mut last_dc = [0i16; 4];
 
@@ -121,19 +118,19 @@ pub fn read_scan<R: Read>(
                 ExitCode::UnsupportedJpeg,
                 "progress must start with DC stage",
             )
-            .context(here!());
+            .context();
         }
 
         // if we saw a pad bit at the end of the block, then remember whether they were 1s or 0s. This
         // will be used later on to reconstruct the padding
         bit_reader
             .read_and_verify_fill_bits(&mut lp.pad_bit)
-            .context(here!())?;
+            .context()?;
 
         // verify that we got the right RST code here since the above should do 1 mcu.
         // If we didn't then we won't re-encode the file binary identical so there's no point in continuing
         if sta == JPegDecodeStatus::RestartIntervalExpired {
-            bit_reader.verify_reset_code().context(here!())?;
+            bit_reader.verify_reset_code().context()?;
 
             sta = JPegDecodeStatus::DecodeInProgress;
         }
@@ -204,11 +201,11 @@ pub fn read_progressive_scan<R: Read>(
                     ExitCode::UnsupportedJpeg,
                     "progress can't have two DC first stages",
                 )
-                .context(here!());
+                .context();
             }
 
             // only need DC
-            jf.verify_huffman_table(true, false).context(here!())?;
+            jf.verify_huffman_table(true, false).context()?;
 
             while sta == JPegDecodeStatus::DecodeInProgress {
                 let current_block = image_data[state.get_cmp()].get_block_mut(state.get_dpos());
@@ -242,7 +239,7 @@ pub fn read_progressive_scan<R: Read>(
             }
 
             // only need AC
-            jf.verify_huffman_table(false, true).context(here!())?;
+            jf.verify_huffman_table(false, true).context()?;
 
             if jf.cs_sah == 0 {
                 if jf.cs_cmpc != 1 {
@@ -268,14 +265,14 @@ pub fn read_progressive_scan<R: Read>(
                             jf.cs_from,
                             jf.cs_to,
                         )
-                        .context(here!())?;
+                        .context()?;
 
                         state
                             .check_optimal_eobrun(
                                 eob == jf.cs_from,
                                 jf.get_huff_ac_codes(state.get_cmp()),
                             )
-                            .context(here!())?;
+                            .context()?;
 
                         for bpos in jf.cs_from..eob {
                             current_block.set_transposed_from_zigzag(
@@ -285,7 +282,7 @@ pub fn read_progressive_scan<R: Read>(
                         }
                     }
 
-                    sta = state.skip_eobrun(&jf).context(here!())?;
+                    sta = state.skip_eobrun(&jf).context()?;
 
                     // proceed only if no error encountered
                     if sta == JPegDecodeStatus::DecodeInProgress {
@@ -315,14 +312,14 @@ pub fn read_progressive_scan<R: Read>(
                             jf.cs_from,
                             jf.cs_to,
                         )
-                        .context(here!())?;
+                        .context()?;
 
                         state
                             .check_optimal_eobrun(
                                 eob == jf.cs_from,
                                 jf.get_huff_ac_codes(state.get_cmp()),
                             )
-                            .context(here!())?;
+                            .context()?;
                     } else {
                         // decode zero run block (short routine)
                         decode_eobrun_sa(
@@ -332,7 +329,7 @@ pub fn read_progressive_scan<R: Read>(
                             jf.cs_from,
                             jf.cs_to,
                         )
-                        .context(here!())?;
+                        .context()?;
                     }
 
                     // copy back to colldata
@@ -354,12 +351,12 @@ pub fn read_progressive_scan<R: Read>(
         // will be used later on to reconstruct the padding
         bit_reader
             .read_and_verify_fill_bits(&mut lp.pad_bit)
-            .context(here!())?;
+            .context()?;
 
         // verify that we got the right RST code here since the above should do 1 mcu.
         // If we didn't then we won't re-encode the file binary identical so there's no point in continuing
         if sta == JPegDecodeStatus::RestartIntervalExpired {
-            bit_reader.verify_reset_code().context(here!())?;
+            bit_reader.verify_reset_code().context()?;
 
             sta = JPegDecodeStatus::DecodeInProgress;
         }
@@ -379,9 +376,7 @@ fn decode_baseline_rst<R: Read>(
     do_handoff: &mut bool,
 ) -> Result<JPegDecodeStatus> {
     // should have both AC and DC components
-    lp.jpeg_header
-        .verify_huffman_table(true, true)
-        .context(here!())?;
+    lp.jpeg_header.verify_huffman_table(true, true).context()?;
 
     let mut sta = JPegDecodeStatus::DecodeInProgress;
     let mut lastdc = [0i16; 4]; // (re)set last DCs for diff coding
@@ -672,7 +667,7 @@ fn decode_ac_prg_sa<R: Read>(
                 let n = bit_reader.read(1)?;
                 v = if n == 0 { -1 } else { 1 }; // fast decode vli
             } else {
-                return err_exit_code(ExitCode::UnsupportedJpeg, "decoding error").context(here!());
+                return err_exit_code(ExitCode::UnsupportedJpeg, "decoding error").context();
             }
 
             // write zeroes / write correction bits
@@ -693,8 +688,7 @@ fn decode_ac_prg_sa<R: Read>(
                 }
 
                 if bpos >= to {
-                    return err_exit_code(ExitCode::UnsupportedJpeg, "decoding error")
-                        .context(here!());
+                    return err_exit_code(ExitCode::UnsupportedJpeg, "decoding error").context();
                 }
 
                 bpos += 1;

--- a/src/structs/jpeg_write.rs
+++ b/src/structs/jpeg_write.rs
@@ -32,25 +32,19 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-use anyhow::{Context, Result};
 use bytemuck::{cast, cast_ref};
 use wide::{i16x16, CmpEq};
 
-use crate::{
-    consts::{JPegDecodeStatus, JPegType},
-    helpers::{err_exit_code, here, u16_bit_length},
-    jpeg_code,
-    lepton_error::ExitCode,
-    structs::block_based_image::AlignedBlock,
-};
+use crate::consts::{JPegDecodeStatus, JPegType};
+use crate::helpers::u16_bit_length;
+use crate::lepton_error::{err_exit_code, AddContext, ExitCode};
+use crate::structs::bit_writer::BitWriter;
+use crate::structs::block_based_image::{AlignedBlock, BlockBasedImage};
+use crate::structs::jpeg_header::{HuffCodes, JPegEncodingInfo};
+use crate::structs::jpeg_position_state::JpegPositionState;
+use crate::structs::row_spec::RowSpec;
+use crate::{jpeg_code, Result};
 
-use super::{
-    bit_writer::BitWriter,
-    block_based_image::BlockBasedImage,
-    jpeg_header::{HuffCodes, JPegEncodingInfo},
-    jpeg_position_state::JpegPositionState,
-    row_spec::RowSpec,
-};
 
 /// write a range of rows corresponding to the thread_handoff structure into the writer.
 /// Only works with baseline non-progressive images.
@@ -104,7 +98,7 @@ pub fn jpeg_write_baseline_row_range(
                 image_data,
                 jenc,
             )
-            .context(here!())?;
+            .context()?;
         }
     }
 
@@ -150,7 +144,7 @@ pub fn jpeg_write_entire_scan(
                 image_data,
                 jenc,
             )
-            .context(here!())?;
+            .context()?;
 
             if r {
                 break;
@@ -260,7 +254,7 @@ fn recode_one_mcu_row(
                         jf.cs_from,
                         jf.cs_to,
                     )
-                    .context(here!())?;
+                    .context()?;
 
                     sta = state.next_mcu_pos(jf);
 
@@ -281,7 +275,7 @@ fn recode_one_mcu_row(
                         jf.cs_to,
                         &mut correction_bits,
                     )
-                    .context(here!())?;
+                    .context()?;
 
                     sta = state.next_mcu_pos(jf);
 
@@ -484,7 +478,7 @@ fn encode_ac_prg_fs(
                 ExitCode::UnsupportedJpeg,
                 "there must be at least one EOB symbol run in the huffman table to encode EOBs",
             )
-            .context(here!());
+            .context();
         }
 
         state.eobrun += 1;
@@ -576,7 +570,7 @@ fn encode_ac_prg_sa(
                 ExitCode::UnsupportedJpeg,
                 "there must be at least one EOB symbol run in the huffman table to encode EOBs",
             )
-            .context(here!());
+            .context();
         }
 
         state.eobrun += 1;
@@ -632,11 +626,11 @@ fn encode_eobrun_bits(s: u8, v: u16) -> u16 {
 /// roundtrips a block through the encoder and decoder and checks that the output matches the input
 #[cfg(test)]
 fn round_trip_block(block: &AlignedBlock, expected: &[u8]) {
-    use crate::structs::jpeg_header::generate_huff_table_from_distribution;
-    use crate::structs::{
-        bit_reader::BitReader, jpeg_header::HuffTree, jpeg_read::decode_block_seq,
-    };
     use std::io::Cursor;
+
+    use crate::structs::bit_reader::BitReader;
+    use crate::structs::jpeg_header::{generate_huff_table_from_distribution, HuffTree};
+    use crate::structs::jpeg_read::decode_block_seq;
 
     let mut bitwriter = BitWriter::new(1024);
 

--- a/src/structs/jpeg_write.rs
+++ b/src/structs/jpeg_write.rs
@@ -45,7 +45,6 @@ use crate::structs::jpeg_position_state::JpegPositionState;
 use crate::structs::row_spec::RowSpec;
 use crate::{jpeg_code, Result};
 
-
 /// write a range of rows corresponding to the thread_handoff structure into the writer.
 /// Only works with baseline non-progressive images.
 pub fn jpeg_write_baseline_row_range(

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -27,7 +27,6 @@ use crate::structs::truncate_components::*;
 use crate::structs::vpx_bool_reader::VPXBoolReader;
 use crate::Result;
 
-
 // reads stream from reader and populates image_data with the decoded data
 
 #[inline(never)] // don't inline so that the profiler can get proper data

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -4,30 +4,29 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
-use anyhow::{Context, Result};
-
-use bytemuck::cast_mut;
-use wide::i32x8;
-
-use default_boxed::DefaultBoxed;
-
 use std::cmp;
 use std::io::Read;
 
+use bytemuck::cast_mut;
+use default_boxed::DefaultBoxed;
+use wide::i32x8;
+
 use crate::consts::UNZIGZAG_49_TR;
 use crate::enabled_features::EnabledFeatures;
-use crate::helpers::{err_exit_code, here, u16_bit_length};
-use crate::lepton_error::ExitCode;
-
+use crate::helpers::u16_bit_length;
+use crate::lepton_error::{err_exit_code, AddContext, ExitCode};
 use crate::metrics::Metrics;
-use crate::structs::{
-    block_based_image::AlignedBlock, block_based_image::BlockBasedImage, model::Model,
-    model::ModelPerColor, neighbor_summary::NeighborSummary, probability_tables::ProbabilityTables,
-    quantization_tables::QuantizationTables, row_spec::RowSpec, truncate_components::*,
-    vpx_bool_reader::VPXBoolReader,
-};
+use crate::structs::block_based_image::{AlignedBlock, BlockBasedImage};
+use crate::structs::block_context::{BlockContext, NeighborData};
+use crate::structs::model::{Model, ModelPerColor};
+use crate::structs::neighbor_summary::NeighborSummary;
+use crate::structs::probability_tables::ProbabilityTables;
+use crate::structs::quantization_tables::QuantizationTables;
+use crate::structs::row_spec::RowSpec;
+use crate::structs::truncate_components::*;
+use crate::structs::vpx_bool_reader::VPXBoolReader;
+use crate::Result;
 
-use super::block_context::{BlockContext, NeighborData};
 
 // reads stream from reader and populates image_data with the decoded data
 
@@ -118,7 +117,7 @@ pub fn lepton_decode_row_range<R: Read>(
             component_size_in_blocks[component],
             features,
         )
-        .context(here!())?;
+        .context()?;
     }
     Ok(bool_reader.drain_stats())
 }
@@ -160,7 +159,7 @@ fn decode_row_wrapper<R: Read>(
                 color_index,
                 features,
             )
-            .context(here!())?;
+            .context()?;
         } else {
             parse_token::<R, false>(
                 model,
@@ -173,7 +172,7 @@ fn decode_row_wrapper<R: Read>(
                 color_index,
                 features,
             )
-            .context(here!())?;
+            .context()?;
         }
 
         let offset = block_context.next();
@@ -426,7 +425,7 @@ fn decode_one_edge<R: Read, const ALL_PRESENT: bool, const HORIZONTAL: bool>(
 ) -> Result<()> {
     let mut num_non_zeros_edge = model_per_color
         .read_non_zero_edge_count::<R, HORIZONTAL>(bool_reader, est_eob, num_non_zeros_bin)
-        .context(here!())?;
+        .context()?;
 
     let delta;
     let mut zig15offset;

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -27,7 +27,6 @@ use crate::structs::truncate_components::*;
 use crate::structs::vpx_bool_writer::VPXBoolWriter;
 use crate::Result;
 
-
 #[inline(never)] // don't inline so that the profiler can get proper data
 pub fn lepton_encode_row_range<W: Write>(
     quantization_tables: &[QuantizationTables],

--- a/src/structs/lepton_file_writer.rs
+++ b/src/structs/lepton_file_writer.rs
@@ -4,31 +4,28 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
-use byteorder::{LittleEndian, WriteBytesExt};
-use default_boxed::DefaultBoxed;
-use log::info;
 use std::cmp;
 use std::io::{Cursor, Read, Seek, SeekFrom, Write};
 use std::time::Instant;
 
-use anyhow::{Context, Result};
+use byteorder::{LittleEndian, WriteBytesExt};
+use default_boxed::DefaultBoxed;
+use log::info;
 
 use crate::consts::*;
 use crate::enabled_features::EnabledFeatures;
-use crate::helpers::*;
 use crate::jpeg_code;
-use crate::lepton_error::ExitCode;
+use crate::lepton_error::{err_exit_code, AddContext, ExitCode, Result};
 use crate::metrics::{CpuTimeMeasure, Metrics};
 use crate::structs::block_based_image::BlockBasedImage;
 use crate::structs::jpeg_header::JPegHeader;
+use crate::structs::jpeg_read::{read_progressive_scan, read_scan};
 use crate::structs::lepton_encoder::lepton_encode_row_range;
 use crate::structs::lepton_file_reader::decode_lepton_file;
+use crate::structs::lepton_header::LeptonHeader;
 use crate::structs::multiplexer::multiplex_write;
 use crate::structs::thread_handoff::ThreadHandoff;
 use crate::structs::truncate_components::TruncateComponents;
-
-use super::jpeg_read::{read_progressive_scan, read_scan};
-use super::lepton_header::LeptonHeader;
 
 /// reads a jpeg and writes it out as a lepton file
 pub fn encode_lepton_wrapper<R: Read + Seek, W: Write + Seek>(
@@ -38,8 +35,7 @@ pub fn encode_lepton_wrapper<R: Read + Seek, W: Write + Seek>(
 ) -> Result<Metrics> {
     let (lp, image_data) = read_jpeg(reader, enabled_features, |_jh| {})?;
 
-    lp.write_lepton_header(writer, enabled_features)
-        .context(here!())?;
+    lp.write_lepton_header(writer, enabled_features).context()?;
 
     let metrics = run_lepton_encoder_threads(
         &lp.jpeg_header,
@@ -49,13 +45,13 @@ pub fn encode_lepton_wrapper<R: Read + Seek, W: Write + Seek>(
         image_data,
         enabled_features,
     )
-    .context(here!())?;
+    .context()?;
 
     let final_file_size = writer.stream_position()? + 4;
 
     writer
         .write_u32::<LittleEndian>(final_file_size as u32)
-        .context(here!())?;
+        .context()?;
 
     Ok(metrics)
 }
@@ -74,7 +70,7 @@ pub fn encode_lepton_wrapper_verify(
     let mut writer = Cursor::new(&mut output_data);
 
     let mut metrics =
-        encode_lepton_wrapper(&mut reader, &mut writer, &enabled_features).context(here!())?;
+        encode_lepton_wrapper(&mut reader, &mut writer, &enabled_features).context()?;
 
     // decode and compare to original in order to enure we encoded correctly
 
@@ -85,9 +81,8 @@ pub fn encode_lepton_wrapper_verify(
 
     let mut c = enabled_features.clone();
 
-    metrics.merge_from(
-        decode_lepton_file(&mut verifyreader, &mut verify_buffer, &mut c).context(here!())?,
-    );
+    metrics
+        .merge_from(decode_lepton_file(&mut verifyreader, &mut verify_buffer, &mut c).context()?);
 
     if input_data.len() != verify_buffer.len() {
         return err_exit_code(
@@ -132,7 +127,7 @@ pub fn read_jpeg<R: Read + Seek>(
 
     get_git_revision(&mut lp);
 
-    if !prepare_to_decode_next_scan(&mut lp, reader, enabled_features).context(here!())? {
+    if !prepare_to_decode_next_scan(&mut lp, reader, enabled_features).context()? {
         return err_exit_code(ExitCode::UnsupportedJpeg, "JPeg does not contain scans");
     }
 
@@ -143,7 +138,7 @@ pub fn read_jpeg<R: Read + Seek>(
             ExitCode::ProgressiveUnsupported,
             "file is progressive, but this is disabled",
         )
-        .context(here!());
+        .context();
     }
 
     if lp.jpeg_header.cmpc > COLOR_CHANNEL_NUM_BLOCK_TYPES {
@@ -151,7 +146,7 @@ pub fn read_jpeg<R: Read + Seek>(
             ExitCode::Unsupported4Colors,
             " can't support this kind of image",
         )
-        .context(here!());
+        .context();
     }
 
     lp.truncate_components.init(&lp.jpeg_header);
@@ -168,7 +163,7 @@ pub fn read_jpeg<R: Read + Seek>(
 
     let mut thread_handoff = Vec::<ThreadHandoff>::new();
     let start_scan = reader.stream_position()? as i32;
-    read_scan(&mut lp, reader, &mut thread_handoff, &mut image_data[..]).context(here!())?;
+    read_scan(&mut lp, reader, &mut thread_handoff, &mut image_data[..]).context()?;
     lp.scnc += 1;
 
     let mut end_scan = reader.stream_position()? as i32;
@@ -179,7 +174,7 @@ pub fn read_jpeg<R: Read + Seek>(
             ExitCode::UnsupportedJpeg,
             "couldnt find any sections to encode",
         )
-        .context(here!());
+        .context();
     }
 
     for i in 0..thread_handoff.len() {
@@ -216,7 +211,7 @@ pub fn read_jpeg<R: Read + Seek>(
         }
 
         // rest of data is garbage data if it is a sequential jpeg (including EOI marker)
-        reader.read_to_end(&mut lp.garbage_data).context(here!())?;
+        reader.read_to_end(&mut lp.garbage_data).context()?;
     } else {
         assert!(lp.jpeg_header.jpeg_type == JPegType::Progressive);
 
@@ -225,14 +220,14 @@ pub fn read_jpeg<R: Read + Seek>(
                 ExitCode::UnsupportedJpeg,
                 "truncation is only supported for baseline images",
             )
-            .context(here!());
+            .context();
         }
 
         // for progressive images, loop around reading headers and decoding until we a complete image_data
-        while prepare_to_decode_next_scan(&mut lp, reader, enabled_features).context(here!())? {
+        while prepare_to_decode_next_scan(&mut lp, reader, enabled_features).context()? {
             callback(&lp.jpeg_header);
 
-            read_progressive_scan(&mut lp, reader, &mut image_data[..]).context(here!())?;
+            read_progressive_scan(&mut lp, reader, &mut image_data[..]).context()?;
             lp.scnc += 1;
 
             if lp.early_eof_encountered {
@@ -240,7 +235,7 @@ pub fn read_jpeg<R: Read + Seek>(
                     ExitCode::UnsupportedJpeg,
                     "truncation is only supported for baseline images",
                 )
-                .context(here!());
+                .context();
             }
         }
 
@@ -251,7 +246,7 @@ pub fn read_jpeg<R: Read + Seek>(
         lp.garbage_data = Vec::from(EOI);
 
         // append the rest of the file to the buffer
-        if reader.read_to_end(&mut lp.garbage_data).context(here!())? == 0 {
+        if reader.read_to_end(&mut lp.garbage_data).context()? == 0 {
             // no need to record EOI garbage data if there wasn't anything read
             lp.garbage_data.clear();
         }
@@ -261,7 +256,7 @@ pub fn read_jpeg<R: Read + Seek>(
     let merged_handoffs =
         split_row_handoffs_to_threads(&thread_handoff[..], enabled_features.max_threads as usize);
     lp.thread_handoff = merged_handoffs;
-    lp.jpeg_file_size = reader.stream_position().context(here!())? as u32;
+    lp.jpeg_file_size = reader.stream_position().context()? as u32;
     Ok((lp, image_data))
 }
 
@@ -335,7 +330,7 @@ fn run_lepton_encoder_threads<W: Write + Seek>(
                 true,
                 &features,
             )
-            .context(here!())?;
+            .context()?;
 
             range_metrics.record_cpu_worker_time(cpu_time.elapsed());
 
@@ -443,10 +438,7 @@ fn prepare_to_decode_next_scan<R: Read>(
     enabled_features: &EnabledFeatures,
 ) -> Result<bool> {
     // parse the header and store it in the raw_jpeg_header
-    if !lp
-        .parse_jpeg_header(reader, enabled_features)
-        .context(here!())?
-    {
+    if !lp.parse_jpeg_header(reader, enabled_features).context()? {
         return Ok(false);
     }
 

--- a/src/structs/lepton_header.rs
+++ b/src/structs/lepton_header.rs
@@ -2,20 +2,17 @@ use std::io::{Cursor, ErrorKind, Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use default_boxed::DefaultBoxed;
-
-use crate::helpers::{buffer_prefix_matches_marker, err_exit_code, here};
-use crate::EnabledFeatures;
-use crate::{consts::*, ExitCode};
-
-use super::{
-    jpeg_header::JPegHeader, thread_handoff::ThreadHandoff, truncate_components::TruncateComponents,
-};
-
-use anyhow::{Context, Result};
-
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
+
+use crate::consts::*;
+use crate::helpers::buffer_prefix_matches_marker;
+use crate::lepton_error::{err_exit_code, AddContext, ExitCode, Result};
+use crate::structs::jpeg_header::JPegHeader;
+use crate::structs::thread_handoff::ThreadHandoff;
+use crate::structs::truncate_components::TruncateComponents;
+use crate::EnabledFeatures;
 
 pub const FIXED_HEADER_SIZE: usize = 28;
 
@@ -161,7 +158,7 @@ impl LeptonHeader {
 
         self.raw_jpeg_header = self
             .read_lepton_compressed_header(&mut compressed_reader)
-            .context(here!())?;
+            .context()?;
 
         self.raw_jpeg_header_read_index = 0;
 
@@ -169,7 +166,7 @@ impl LeptonHeader {
             let mut header_data_cursor = Cursor::new(&self.raw_jpeg_header[..]);
             self.jpeg_header
                 .parse(&mut header_data_cursor, &enabled_features)
-                .context(here!())?;
+                .context()?;
             self.raw_jpeg_header_read_index = header_data_cursor.position() as usize;
         }
 
@@ -221,7 +218,7 @@ impl LeptonHeader {
         let result = self
             .jpeg_header
             .parse(&mut header_cursor, enabled_features)
-            .context(here!())?;
+            .context()?;
 
         self.raw_jpeg_header_read_index += header_cursor.stream_position()? as usize;
 
@@ -263,7 +260,7 @@ impl LeptonHeader {
                     if e.kind() == ErrorKind::UnexpectedEof {
                         break;
                     } else {
-                        return Err(anyhow::Error::new(e));
+                        return Err(e.into());
                     }
                 }
             }
@@ -368,8 +365,8 @@ impl LeptonHeader {
             let mut c = Cursor::new(&mut compressed_header);
             let mut encoder = ZlibEncoder::new(&mut c, Compression::default());
 
-            encoder.write_all(&lepton_header[..]).context(here!())?;
-            encoder.finish().context(here!())?;
+            encoder.write_all(&lepton_header[..]).context()?;
+            encoder.finish().context()?;
         }
 
         writer.write_all(&LEPTON_FILE_HEADER)?;
@@ -541,7 +538,7 @@ impl LeptonHeader {
         if self
             .jpeg_header
             .parse(&mut mirror, enabled_features)
-            .context(here!())?
+            .context()?
         {
             // append the header if it was not the end of file marker
             self.raw_jpeg_header.append(&mut output);

--- a/src/structs/multiplexer.rs
+++ b/src/structs/multiplexer.rs
@@ -1,23 +1,20 @@
+use std::cmp;
+use std::collections::VecDeque;
+use std::io::{Cursor, Read, Write};
+use std::mem::swap;
+use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::{Arc, Mutex};
+
+use byteorder::WriteBytesExt;
+
+use crate::lepton_error::{AddContext, ExitCode, LeptonError, Result};
 /// Implements a multiplexer that reads and writes blocks to a stream from multiple threads.
 ///
 /// The write implementation identifies the blocks by thread_id and tries to write in 64K blocks. The file
 /// ends up with an interleaved stream of blocks from each thread.
 ///
 /// The read implementation reads the blocks from the file and sends them to the appropriate worker thread.
-use crate::{helpers::*, structs::partial_buffer::PartialBuffer, ExitCode, LeptonError};
-use anyhow::{Context, Result};
-use byteorder::WriteBytesExt;
-
-use std::{
-    cmp,
-    collections::VecDeque,
-    io::{Cursor, Read, Write},
-    mem::swap,
-    sync::{
-        mpsc::{channel, Receiver, Sender},
-        Arc, Mutex,
-    },
-};
+use crate::{helpers::*, lepton_error::err_exit_code, structs::partial_buffer::PartialBuffer};
 
 /// The message that is sent between the threads
 enum Message {
@@ -156,9 +153,9 @@ where
             let f = move || -> Result<RESULT> {
                 let r = processor_clone(&mut thread_writer, thread_id)?;
 
-                thread_writer.flush().context(here!())?;
+                thread_writer.flush().context()?;
 
-                thread_writer.sender.send(Message::Eof).context(here!())?;
+                thread_writer.sender.send(Message::Eof).context()?;
                 Ok(r)
             };
 
@@ -174,7 +171,7 @@ where
         let mut threads_left = num_threads;
 
         while threads_left > 0 {
-            let value = rx.recv().context(here!());
+            let value = rx.recv().context();
             match value {
                 Ok(Message::Eof) => {
                     threads_left -= 1;
@@ -182,10 +179,10 @@ where
                 Ok(Message::WriteBlock(thread_id, b)) => {
                     let l = b.len() - 1;
 
-                    writer.write_u8(thread_id).context(here!())?;
-                    writer.write_u8((l & 0xff) as u8).context(here!())?;
-                    writer.write_u8(((l >> 8) & 0xff) as u8).context(here!())?;
-                    writer.write_all(&b[..]).context(here!())?;
+                    writer.write_u8(thread_id).context()?;
+                    writer.write_u8((l & 0xff) as u8).context()?;
+                    writer.write_u8(((l >> 8) & 0xff) as u8).context()?;
+                    writer.write_all(&b[..]).context()?;
                 }
                 Err(_) => {
                     // if we get a receiving error here, this means that one of the threads broke
@@ -198,7 +195,7 @@ where
         // in place scope will join all the threads before it exits
         return Ok(());
     })
-    .context(here!())?;
+    .context()?;
 
     let mut thread_not_run = false;
     let mut results = Vec::new();
@@ -277,7 +274,7 @@ impl MultiplexReader {
                     }
                 },
                 Err(e) => {
-                    return Result::Err(std::io::Error::new(std::io::ErrorKind::Other, e));
+                    return std::io::Result::Err(std::io::Error::new(std::io::ErrorKind::Other, e));
                 }
             }
         }
@@ -449,7 +446,7 @@ impl<RESULT> MultiplexReaderState<RESULT> {
 
         let mut error = None;
         for _i in 0..self.sender_channels.len() {
-            match self.result_receiver.recv().context(here!())? {
+            match self.result_receiver.recv().context()? {
                 (thread_id, Ok(r)) => {
                     results[thread_id] = Some(r);
                 }
@@ -460,7 +457,7 @@ impl<RESULT> MultiplexReaderState<RESULT> {
         }
 
         if let Some(e) = error {
-            Err(e).context(here!())
+            Err(e).context()
         } else {
             let results: Vec<RESULT> = results.into_iter().map(|x| x.unwrap()).collect();
             Ok(results)
@@ -516,7 +513,7 @@ fn test_multiplex_read_error() {
 
     let e: LeptonError = multiplex_state.complete().unwrap_err().into();
     assert_eq!(e.exit_code(), ExitCode::FileNotFound);
-    assert_eq!(e.message(), "test error");
+    assert!(e.message().starts_with("test error"));
 }
 
 #[test]
@@ -546,7 +543,7 @@ fn test_multiplex_write_error() {
     .into();
 
     assert_eq!(e.exit_code(), ExitCode::FileNotFound);
-    assert_eq!(e.message(), "test error");
+    assert!(e.message().starts_with("test error"));
 }
 
 // test catching errors in the multiplex_write function

--- a/src/structs/probability_tables.rs
+++ b/src/structs/probability_tables.rs
@@ -4,17 +4,15 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
+use wide::{i16x8, i32x8};
+
 use crate::consts::*;
 use crate::enabled_features;
+use crate::structs::block_based_image::AlignedBlock;
+use crate::structs::block_context::NeighborData;
 use crate::structs::idct::*;
 use crate::structs::model::*;
 use crate::structs::quantization_tables::*;
-
-use super::block_based_image::AlignedBlock;
-use super::block_context::NeighborData;
-
-use wide::i16x8;
-use wide::i32x8;
 
 pub struct ProbabilityTables {
     left_present: bool,

--- a/src/structs/quantization_tables.rs
+++ b/src/structs/quantization_tables.rs
@@ -6,8 +6,7 @@
 
 use crate::consts::*;
 use crate::helpers::*;
-
-use super::jpeg_header::JPegHeader;
+use crate::structs::jpeg_header::JPegHeader;
 
 pub struct QuantizationTables {
     quantization_table: [u16; 64],

--- a/src/structs/row_spec.rs
+++ b/src/structs/row_spec.rs
@@ -5,8 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 use crate::consts::COLOR_CHANNEL_NUM_BLOCK_TYPES;
-
-use super::block_based_image::BlockBasedImage;
+use crate::structs::block_based_image::BlockBasedImage;
 
 pub struct RowSpec {
     pub min_row_luma_y: i32,

--- a/src/structs/truncate_components.rs
+++ b/src/structs/truncate_components.rs
@@ -4,11 +4,10 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
-use crate::structs::component_info::*;
-
 use std::cmp;
 
-use super::jpeg_header::JPegHeader;
+use crate::structs::component_info::*;
+use crate::structs::jpeg_header::JPegHeader;
 
 #[derive(Debug, Clone)]
 struct TrucateComponentsInfo {

--- a/src/structs/vpx_bool_reader.rs
+++ b/src/structs/vpx_bool_reader.rs
@@ -25,8 +25,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
 use std::io::{Read, Result};
 
 use crate::metrics::{Metrics, ModelComponent};
-
-use super::{branch::Branch, simple_hash::SimpleHash};
+use crate::structs::branch::Branch;
+use crate::structs::simple_hash::SimpleHash;
 
 const BITS_IN_BYTE: u32 = 8;
 const BITS_IN_VALUE: u32 = 64;

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -25,8 +25,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
 use std::io::{Result, Write};
 
 use crate::metrics::{Metrics, ModelComponent};
-
-use super::{branch::Branch, simple_hash::SimpleHash};
+use crate::structs::branch::Branch;
+use crate::structs::simple_hash::SimpleHash;
 
 pub struct VPXBoolWriter<W> {
     low_value: u32,
@@ -318,7 +318,7 @@ impl<W: Write> VPXBoolWriter<W> {
 }
 
 #[cfg(test)]
-use super::vpx_bool_reader::VPXBoolReader;
+use crate::structs::vpx_bool_reader::VPXBoolReader;
 
 #[test]
 fn test_roundtrip_vpxboolwriter_n_bits() {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -5,21 +5,16 @@
  *--------------------------------------------------------------------------------------------*/
 
 use core::result::Result;
-use std::{io::Cursor, path::Path};
-
 use std::fs::File;
-use std::io::Read;
+use std::io::{Cursor, Read};
+use std::path::Path;
 
+use lepton_jpeg::lepton_error::{ExitCode, LeptonError};
 use lepton_jpeg::{
-    create_decompression_context, decompress_image, free_decompression_context,
-    WrapperCompressImage, WrapperDecompressImage, WrapperDecompressImageEx,
+    create_decompression_context, decode_lepton, decompress_image, encode_lepton,
+    encode_lepton_verify, free_decompression_context, EnabledFeatures, WrapperCompressImage,
+    WrapperDecompressImage, WrapperDecompressImageEx,
 };
-use lepton_jpeg::{
-    decode_lepton, encode_lepton, encode_lepton_verify,
-    lepton_error::{ExitCode, LeptonError},
-    EnabledFeatures,
-};
-
 use rstest::rstest;
 
 fn read_file(filename: &str, ext: &str) -> Vec<u8> {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -279,29 +279,30 @@ fn verify_16bitmath() {
 #[test]
 fn verify_extern_16bit_math_retry() {
     // verify retry logic for 16 bit math encoded image
+    for i in 0..10 {
+        let compressed = read_file("mathoverflow_16", ".lep");
 
-    let compressed = read_file("mathoverflow_16", ".lep");
+        let input = read_file("mathoverflow", ".jpg");
 
-    let input = read_file("mathoverflow", ".jpg");
+        let mut original = Vec::new();
+        original.resize(input.len() + 10000, 0);
 
-    let mut original = Vec::new();
-    original.resize(input.len() + 10000, 0);
+        let mut original_size: u64 = 0;
+        unsafe {
+            let retval = WrapperDecompressImage(
+                compressed[..].as_ptr(),
+                compressed.len() as u64,
+                original[..].as_mut_ptr(),
+                original.len() as u64,
+                8,
+                (&mut original_size) as *mut u64,
+            );
 
-    let mut original_size: u64 = 0;
-    unsafe {
-        let retval = WrapperDecompressImage(
-            compressed[..].as_ptr(),
-            compressed.len() as u64,
-            original[..].as_mut_ptr(),
-            original.len() as u64,
-            8,
-            (&mut original_size) as *mut u64,
-        );
-
-        assert_eq!(retval, 0);
+            assert_eq!(retval, 0);
+        }
+        assert_eq!(input.len() as u64, original_size);
+        assert_eq!(input[..], original[..(original_size as usize)]);
     }
-    assert_eq!(input.len() as u64, original_size);
-    assert_eq!(input[..], original[..(original_size as usize)]);
 }
 
 /// encodes as LEP and codes back to JPG to mostly test the encoder. Can't check against

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -279,30 +279,28 @@ fn verify_16bitmath() {
 #[test]
 fn verify_extern_16bit_math_retry() {
     // verify retry logic for 16 bit math encoded image
-    for i in 0..10 {
-        let compressed = read_file("mathoverflow_16", ".lep");
+    let compressed = read_file("mathoverflow_16", ".lep");
 
-        let input = read_file("mathoverflow", ".jpg");
+    let input = read_file("mathoverflow", ".jpg");
 
-        let mut original = Vec::new();
-        original.resize(input.len() + 10000, 0);
+    let mut original = Vec::new();
+    original.resize(input.len() + 10000, 0);
 
-        let mut original_size: u64 = 0;
-        unsafe {
-            let retval = WrapperDecompressImage(
-                compressed[..].as_ptr(),
-                compressed.len() as u64,
-                original[..].as_mut_ptr(),
-                original.len() as u64,
-                8,
-                (&mut original_size) as *mut u64,
-            );
+    let mut original_size: u64 = 0;
+    unsafe {
+        let retval = WrapperDecompressImage(
+            compressed[..].as_ptr(),
+            compressed.len() as u64,
+            original[..].as_mut_ptr(),
+            original.len() as u64,
+            8,
+            (&mut original_size) as *mut u64,
+        );
 
-            assert_eq!(retval, 0);
-        }
-        assert_eq!(input.len() as u64, original_size);
-        assert_eq!(input[..], original[..(original_size as usize)]);
+        assert_eq!(retval, 0);
     }
+    assert_eq!(input.len() as u64, original_size);
+    assert_eq!(input[..], original[..(original_size as usize)]);
 }
 
 /// encodes as LEP and codes back to JPG to mostly test the encoder. Can't check against


### PR DESCRIPTION
This is a bunch of changes, but shouldn't change any functionality. The overhead of the LeptonError class should be minimal for the non-error case and a bit expensive for errors since they are few and far between.

I also ran the nightly formatter on use statements to clean up the mess that had built up.