### PR TITLE
Shorter blocks and consistent file

### DIFF
--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -117,6 +117,8 @@ pub fn lepton_encode_row_range<W: Write>(
             features,
         )
         .context()?;
+
+        bool_writer.flush_non_final_data().context()?;
     }
 
     if is_last_thread && full_file_compression {

--- a/src/structs/multiplexer.rs
+++ b/src/structs/multiplexer.rs
@@ -189,7 +189,7 @@ where
             }
         }
 
-        // carousseling to write data packets from all threads
+        // carouseling to write data packets from all threads
         if threads_left == 0 {
             for i in &packets {
                 threads_left += if i.len() > 0 { 1 } else { 0 };
@@ -197,7 +197,6 @@ where
 
             let mut curr_write_thread: usize = 0;
             while threads_left > 0 {
-                curr_write_thread = (curr_write_thread + 1) % num_threads;
                 if packets[curr_write_thread].len() > 0 {
                     let a = packets[curr_write_thread].pop_front().unwrap();
                     let mut c = curr_write_thread as u8;
@@ -218,6 +217,7 @@ where
                         threads_left -= 1;
                     }
                 }
+                curr_write_thread = (curr_write_thread + 1) % num_threads;
             }
         }
 

--- a/src/structs/multiplexer.rs
+++ b/src/structs/multiplexer.rs
@@ -213,12 +213,8 @@ where
                         while packets_left > 0 {
                             curr_write_thread = (curr_write_thread + 1) % num_threads;
 
-                            if packets[curr_write_thread].len() > 0 {
-                                write_block(
-                                    curr_write_thread,
-                                    packets[curr_write_thread].pop_front().unwrap(),
-                                )
-                                .context()?;
+                            if let Some(packet) = packets[curr_write_thread].pop_front() {
+                                write_block(curr_write_thread, packet).context()?;
 
                                 packets_left -= 1;
                             }
@@ -229,12 +225,8 @@ where
                         loop {
                             curr_write_thread = (curr_write_thread + 1) % num_threads;
 
-                            if packets[curr_write_thread].len() > 0 {
-                                write_block(
-                                    curr_write_thread,
-                                    packets[curr_write_thread].pop_front().unwrap(),
-                                )
-                                .context()?;
+                            if let Some(packet) = packets[curr_write_thread].pop_front() {
+                                write_block(curr_write_thread, packet).context()?;
                             } else if !eot[curr_write_thread] {
                                 break;
                             }
@@ -250,12 +242,8 @@ where
                         loop {
                             curr_write_thread = (curr_write_thread + 1) % num_threads;
 
-                            if packets[curr_write_thread].len() > 0 {
-                                write_block(
-                                    curr_write_thread,
-                                    packets[curr_write_thread].pop_front().unwrap(),
-                                )
-                                .context()?;
+                            if let Some(packet) = packets[curr_write_thread].pop_front() {
+                                write_block(curr_write_thread, packet).context()?;
                             } else if !eot[curr_write_thread] {
                                 break;
                             }

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -305,6 +305,25 @@ impl<W: Write> VPXBoolWriter<W> {
         self.writer.write_all(&self.buffer[..])?;
         Ok(())
     }
+
+    /// When buffer is full and is going to be sent to output, preserve buffer data that
+    /// is not final and should be carried over to the next buffer.
+    pub fn flush_non_final_data(&mut self) -> Result<()> {
+        // carry over buffer data that might be not final
+        let mut i = self.buffer.len();
+        if i >= 65536 {
+            i -= 1;
+            while self.buffer[i] == 0xFF {
+                assert!(i > 0);
+                i -= 1;
+            }
+
+            self.writer.write_all(&self.buffer[..i])?;
+            self.buffer.drain(..i);
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -52,6 +52,7 @@ impl<W: Write> VPXBoolWriter<W> {
         };
 
         let mut dummy_branch = Branch::new();
+        // initial false bit is put to not get carry out of stream bits
         retval.put_bit(false, &mut dummy_branch, ModelComponent::Dummy)?;
 
         Ok(retval)
@@ -99,14 +100,11 @@ impl<W: Write> VPXBoolWriter<W> {
         if value {
             *tmp_value += split;
             *tmp_range -= split;
-
-            shift = (*tmp_range as u8).leading_zeros() as i32;
         } else {
             *tmp_range = split;
-
-            // optimizer understands that split > 0, so it can optimize this
-            shift = (split as u8).leading_zeros() as i32;
         }
+
+        shift = (*tmp_range as u8).leading_zeros() as i32;
 
         #[cfg(feature = "compression_stats")]
         {
@@ -118,36 +116,38 @@ impl<W: Write> VPXBoolWriter<W> {
         *tmp_count += shift;
 
         if *tmp_count >= 0 {
-            let offset = shift - *tmp_count;
+            let offset = shift - *tmp_count - 1;
 
-            if ((*tmp_value << (offset - 1)) & 0x80000000) != 0 {
-                let mut x = self.buffer.len() - 1;
-
-                while self.buffer[x] == 0xFF {
-                    self.buffer[x] = 0;
-
-                    assert!(x > 0);
-                    x -= 1;
-                }
-
-                self.buffer[x] += 1;
+            *tmp_value <<= offset;
+            if (*tmp_value & 0x80000000) != 0 {
+                self.carry();
             }
 
-            self.buffer.push((*tmp_value >> (24 - offset)) as u8);
-            *tmp_value <<= offset;
-            shift = *tmp_count;
+            *tmp_value <<= 1;
+            self.buffer.push((*tmp_value >> 24) as u8);
             *tmp_value &= 0xffffff;
+
+            shift = *tmp_count;
             *tmp_count -= 8;
         }
 
         *tmp_value <<= shift;
 
-        // check if we're out of buffer space, if yes - send the buffer to output
-        if self.buffer.len() > 65536 - 128 {
-            self.flush_non_final_data()?;
+        Ok(())
+    }
+
+    #[inline(always)] //#[cold]
+    fn carry(&mut self) {
+        let mut x = self.buffer.len() - 1;
+
+        while self.buffer[x] == 0xFF {
+            self.buffer[x] = 0;
+
+            assert!(x > 0);
+            x -= 1;
         }
 
-        Ok(())
+        self.buffer[x] += 1;
     }
 
     #[inline(always)]
@@ -290,29 +290,19 @@ impl<W: Write> VPXBoolWriter<W> {
     }
 
     pub fn finish(&mut self) -> Result<()> {
-        // push real stream bits out of `value`
-        for _i in 0..32 {
-            let mut dummy_branch = Branch::new();
-            self.put_bit(false, &mut dummy_branch, ModelComponent::Dummy)?;
+        // typically all bytes of `low_value` will have stream bits,
+        // so just write them all
+        let tmp_value = self.low_value << (-self.count - 1);
+
+        if (tmp_value & 0x80000000) != 0 {
+            self.carry();
         }
+        self.buffer.push((tmp_value >> 23) as u8);
+        self.buffer.push((tmp_value >> 15) as u8);
+        self.buffer.push((tmp_value >> 7) as u8);
+        self.buffer.push((tmp_value << 1) as u8);
 
         self.writer.write_all(&self.buffer[..])?;
-        Ok(())
-    }
-
-    /// When buffer is full and is going to be sent to output, preserve buffer data that
-    /// is not final and should carried over to the next buffer.
-    fn flush_non_final_data(&mut self) -> Result<()> {
-        // carry over buffer data that might be not final
-        let mut i = self.buffer.len() - 1;
-        while self.buffer[i] == 0xFF {
-            assert!(i > 0);
-            i -= 1;
-        }
-
-        self.writer.write_all(&self.buffer[..i])?;
-        self.buffer.drain(..i);
-
         Ok(())
     }
 }

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -299,14 +299,17 @@ impl<W: Write> VPXBoolWriter<W> {
     /// is not final and should carried over to the next buffer.
     pub fn flush_non_final_data(&mut self) -> Result<()> {
         // carry over buffer data that might be not final
-        let mut i = self.buffer.len() - 1;
-        while self.buffer[i] == 0xFF {
-            assert!(i > 0);
+        let mut i = self.buffer.len();
+        if i > 0 {
             i -= 1;
-        }
+            while self.buffer[i] == 0xFF {
+                assert!(i > 0);
+                i -= 1;
+            }
 
-        self.writer.write_all(&self.buffer[..i])?;
-        self.buffer.drain(..i);
+            self.writer.write_all(&self.buffer[..i])?;
+            self.buffer.drain(..i);
+        }
 
         Ok(())
     }

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -142,11 +142,6 @@ impl<W: Write> VPXBoolWriter<W> {
 
         *tmp_value <<= shift;
 
-        // check if we're out of buffer space, if yes - send the buffer to output
-        if self.buffer.len() > 65536 - 128 {
-            self.flush_non_final_data()?;
-        }
-
         Ok(())
     }
 


### PR DESCRIPTION
Lepton format allows to write blocks of standard length (65536 bytes) shorter, with 1-byte header instead of 3-bytes. Additionally, current implementation writes down encoded blocks into the file in the order of their receiving from different threads - that leads to different output files across runs.

This PR makes the output file shorter and the order of blocks in it predefined by carouseling. Performance is increased by ~3 % due to omission of buffer size check at each stream bit pushing.

Current best of 3 runs:
```
2024-11-14T17:00:03.681Z INFO  [lepton_jpeg::structs::lepton_file_writer] compressing to Lepton format
2024-11-14T17:00:04.152Z INFO  [lepton_jpeg::structs::lepton_file_writer] Number of threads: 8
2024-11-14T17:00:05.668Z INFO  [lepton_jpeg::structs::lepton_file_writer] worker threads 10212ms of CPU time in 1514ms of wall time
2024-11-14T17:00:05.668Z INFO  [lepton_jpeg::structs::lepton_file_writer] decompressing to verify contents
2024-11-14T17:00:07.276Z INFO  [lepton_jpeg_util] compressed input 22171278, output 17324596 bytes (compression = 28.0%)
2024-11-14T17:00:07.276Z INFO  [lepton_jpeg_util] Main thread CPU: 3595ms, Worker thread CPU: 21306 ms, walltime: 3595 ms

 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.jpg images/img_52MP_7k2.lep':

       855 564 085      cache-references                                                        (42,07%)
        86 316 838      cache-misses                     #   10,09% of all cache refs           (42,21%)
    16 099 617 774      cycles                                                                  (42,31%)
       806 699 300      ic_fetch_stall.ic_stall_back_pressure                                        (42,10%)
     1 061 388 071      stalled-cycles-frontend          #    6,59% frontend cycles idle        (41,84%)
    40 125 811 710      instructions                     #    2,49  insn per cycle            
                                                  #    0,03  stalled cycles per insn     (41,72%)
     4 707 746 288      branch-instructions                                                     (41,69%)
       165 544 725      branch-misses                    #    3,52% of all branches             (41,64%)
     5 309 260 356      ic_fetch_stall.ic_stall_any                                             (41,56%)
        43 294 231      ic_fetch_stall.ic_stall_dq_empty                                        (41,80%)
        73 167 746      l2_cache_misses_from_ic_miss                                            (42,11%)
     2 188 259 483      l2_latency.l2_cycles_waiting_on_fills                                        (42,11%)
           183 928      faults                                                                
                 1      migrations                                                            

       3,628985546 seconds time elapsed

       3,289304000 seconds user
       0,336724000 seconds sys
```
This PR  https://github.com/microsoft/lepton_jpeg_rust/pull/112/commits/c7e0f7cea74909140464b08c80b1004f1f0580b6 best of 3 runs:
```
2024-11-14T21:13:33.559Z INFO  [lepton_jpeg::structs::lepton_file_writer] compressing to Lepton format
2024-11-14T21:13:34.039Z INFO  [lepton_jpeg::structs::lepton_file_writer] Number of threads: 8
2024-11-14T21:13:35.420Z INFO  [lepton_jpeg::structs::lepton_file_writer] worker threads 9299ms of CPU time in 1379ms of wall time
2024-11-14T21:13:35.420Z INFO  [lepton_jpeg::structs::lepton_file_writer] decompressing to verify contents
2024-11-14T21:13:37.018Z INFO  [lepton_jpeg_util] compressed input 22171278, output 17324076 bytes (compression = 28.0%)
2024-11-14T21:13:37.018Z INFO  [lepton_jpeg_util] Main thread CPU: 3458ms, Worker thread CPU: 20273 ms, walltime: 3458 ms

 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.jpg images/img_52MP_7k2.lep':

       834 601 112      cache-references                                                        (42,12%)
        64 932 273      cache-misses                     #    7,78% of all cache refs           (42,04%)
    15 586 303 408      cycles                                                                  (42,04%)
       838 269 598      ic_fetch_stall.ic_stall_back_pressure                                        (41,98%)
     1 061 874 437      stalled-cycles-frontend          #    6,81% frontend cycles idle        (41,79%)
    38 330 557 068      instructions                     #    2,46  insn per cycle            
                                                  #    0,03  stalled cycles per insn     (41,68%)
     4 353 138 372      branch-instructions                                                     (41,68%)
       163 333 881      branch-misses                    #    3,75% of all branches             (41,72%)
     5 226 409 949      ic_fetch_stall.ic_stall_any                                             (41,86%)
        39 792 649      ic_fetch_stall.ic_stall_dq_empty                                        (41,92%)
        53 084 247      l2_cache_misses_from_ic_miss                                            (41,96%)
     2 066 007 058      l2_latency.l2_cycles_waiting_on_fills                                        (42,16%)
           183 967      faults                                                                
                 1      migrations                                                            

       3,492682793 seconds time elapsed

       3,175743000 seconds user
       0,313777000 seconds sys
```