### PR TITLE
Create simple threadpool for avoiding constant thread creation

### DIFF
--- a/src/structs/block_context.rs
+++ b/src/structs/block_context.rs
@@ -7,6 +7,7 @@
 use crate::structs::block_based_image::{AlignedBlock, BlockBasedImage, EMPTY_BLOCK};
 use crate::structs::neighbor_summary::{NeighborSummary, NEIGHBOR_DATA_EMPTY};
 use crate::structs::probability_tables::ProbabilityTables;
+
 pub struct BlockContext {
     cur_block_index: i32,
     above_block_index: i32,

--- a/src/structs/block_context.rs
+++ b/src/structs/block_context.rs
@@ -7,7 +7,6 @@
 use crate::structs::block_based_image::{AlignedBlock, BlockBasedImage, EMPTY_BLOCK};
 use crate::structs::neighbor_summary::{NeighborSummary, NEIGHBOR_DATA_EMPTY};
 use crate::structs::probability_tables::ProbabilityTables;
-
 pub struct BlockContext {
     cur_block_index: i32,
     above_block_index: i32,

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -32,6 +32,7 @@ mod probability_tables;
 mod quantization_tables;
 mod row_spec;
 mod simple_hash;
+mod simple_threadpool;
 mod thread_handoff;
 mod truncate_components;
 mod vpx_bool_reader;

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -32,7 +32,10 @@ mod probability_tables;
 mod quantization_tables;
 mod row_spec;
 mod simple_hash;
+
+#[cfg(not(feature = "use_rayon"))]
 mod simple_threadpool;
+
 mod thread_handoff;
 mod truncate_components;
 mod vpx_bool_reader;

--- a/src/structs/multiplexer.rs
+++ b/src/structs/multiplexer.rs
@@ -105,7 +105,9 @@ fn my_spawn_simple<F>(f: F)
 where
     F: FnOnce() + Send + 'static,
 {
-    std::thread::spawn(f);
+    use super::simple_threadpool;
+
+    simple_threadpool::execute(f);
 }
 
 #[cfg(feature = "use_rayon")]

--- a/src/structs/simple_threadpool.rs
+++ b/src/structs/simple_threadpool.rs
@@ -13,13 +13,45 @@
 /// No unsafe code is used.
 use std::{
     sync::{
-        mpsc::{channel, Sender},
-        LazyLock, Mutex,
+        Arc, Condvar, LazyLock, Mutex,
     },
     thread::{self, spawn},
 };
 
-static IDLE_THREADS: LazyLock<Mutex<Vec<Sender<Box<dyn FnOnce() + Send + 'static>>>>> =
+type BoxedTrait = Box<dyn FnOnce() + Send + 'static>;
+
+struct ThreadInPool {
+    m: Mutex<Option<BoxedTrait>>,
+    cond: Condvar,
+}
+
+impl ThreadInPool {
+    fn new() -> Self {
+        ThreadInPool {
+            m: Mutex::new(None),
+            cond: Condvar::new(),
+        }
+    }
+
+    fn put(&self, f: BoxedTrait) {
+        if let Ok(mut m) = self.m.lock() {
+            assert!(m.is_none());
+            *m = Some(f);
+            self.cond.notify_one();
+        }
+    }
+
+    fn take(&self) -> Option<BoxedTrait> {
+        if let Ok(m) = self.m.lock() {
+            if let Ok(mut c) = self.cond.wait(m) {
+                return c.take();
+            }
+        }
+        None
+    }
+}
+
+static IDLE_THREADS: LazyLock<Mutex<Vec<Arc<ThreadInPool>>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 static NUM_CPUS: LazyLock<usize> = LazyLock::new(|| thread::available_parallelism().unwrap().get());
 
@@ -33,35 +65,33 @@ pub fn execute<F>(f: F)
 where
     F: FnOnce() + Send + 'static,
 {
-    if let Some(sender) = IDLE_THREADS.lock().unwrap().pop() {
-        sender.send(Box::new(f)).unwrap();
+    let i = IDLE_THREADS.lock().unwrap().pop();
+
+    if let Some(t) = i {
+        t.put(Box::new(f));
         return;
     }
 
-    let (tx, rx) = channel();
+    let t = Arc::new(ThreadInPool::new());
 
     spawn(move || {
         f();
 
         loop {
             if let Ok(mut i) = IDLE_THREADS.lock() {
-                // stick back into list of idle threads if there aren't more than
-                // the number of cpus already there.
-                if i.len() > *NUM_CPUS {
-                    // just exits the thread
-                    break;
+                // if we don't have more idle threads than CPUs, we can add this thread to the pool
+                if i.len() < *NUM_CPUS {
+                    i.push(t.clone());
+                    drop(i);
+
+                    if let Some(w) = t.take() {
+                        w();
+                        continue;
+                    }
                 }
-                i.push(tx.clone());
-            } else {
-                break;
             }
 
-            if let Ok(f) = rx.recv() {
-                f();
-            } else {
-                // channel broken, exit thread
-                break;
-            }
+            break;
         }
     });
 }

--- a/src/structs/simple_threadpool.rs
+++ b/src/structs/simple_threadpool.rs
@@ -1,0 +1,88 @@
+/// A simple thread pool implementation that can be used to evaluate closures on separate threads.
+///
+/// The pool will keep a number of threads equal to the number of CPUs available on the system, and
+/// will reuse threads that are idle.
+///
+/// If more tasks are submitted than there are threads, the pool will spawn new threads to handle
+/// the extra tasks.
+///
+/// Why write yet another threadpool? There wasn't one that was that supported dynamically growing
+/// the threadpool (rayon and tokio are all fixed), which is important since otherwise there is
+/// unpredicable latency when the number of tasks submitted is greater than the number of threads.
+///
+/// No unsafe code is used.
+use std::{
+    sync::{
+        mpsc::{channel, Sender},
+        LazyLock, Mutex,
+    },
+    thread::{self, spawn},
+};
+
+static IDLE_THREADS: LazyLock<Mutex<Vec<Sender<Box<dyn FnOnce() + Send + 'static>>>>> =
+    LazyLock::new(|| Mutex::new(Vec::new()));
+static NUM_CPUS: LazyLock<usize> = LazyLock::new(|| thread::available_parallelism().unwrap().get());
+
+#[allow(dead_code)]
+pub fn get_idle_threads() -> usize {
+    IDLE_THREADS.lock().unwrap().len()
+}
+
+/// Executes a closure on a thread from the thread pool. Does not block or return any result.
+pub fn execute<F>(f: F)
+where
+    F: FnOnce() + Send + 'static,
+{
+    if let Some(sender) = IDLE_THREADS.lock().unwrap().pop() {
+        sender.send(Box::new(f)).unwrap();
+        return;
+    }
+
+    let (tx, rx) = channel();
+
+    spawn(move || {
+        f();
+
+        loop {
+            if let Ok(mut i) = IDLE_THREADS.lock() {
+                // stick back into list of idle threads if there aren't more than
+                // the number of cpus already there.
+                if i.len() > *NUM_CPUS {
+                    // just exits the thread
+                    break;
+                }
+                i.push(tx.clone());
+            } else {
+                break;
+            }
+
+            if let Ok(f) = rx.recv() {
+                f();
+            } else {
+                // channel broken, exit thread
+                break;
+            }
+        }
+    });
+}
+
+#[test]
+fn test_threadpool() {
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    let a: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
+
+    for _i in 0usize..100 {
+        let aref = a.clone();
+        execute(move || {
+            aref.fetch_add(1, Ordering::AcqRel);
+        });
+    }
+
+    while a.load(std::sync::atomic::Ordering::Acquire) < 100 {
+        thread::yield_now();
+    }
+
+    println!("Idle threads: {}", get_idle_threads());
+}


### PR DESCRIPTION
We're having some trouble with live site profiling since we're always creating threads. Reuse existing threads up to the number of CPUs. There's no upper limit to the number of threads to keep the behavior as similar as possible.