### PR TITLE
No count in bit writer

### DIFF
--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -623,7 +623,7 @@ fn roundtrip_ac_only() {
         &block,
         &block,
         [1; 64],
-        0xC634E0F1A29033CA,
+        0x9F5637364D41FE11,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 }
@@ -656,7 +656,7 @@ fn roundtrip_large_coef() {
         &block,
         &block,
         [1; 64],
-        0x12050FD2C854F927,
+        0x95CBDD4F7D7B72EB,
         &EnabledFeatures::compat_lepton_vector_read(),
     );
 

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -286,12 +286,11 @@ impl<W: Write> VPXBoolWriter<W> {
         let mut tmp_value = self.low_value;
         let stream_bits = 64 - tmp_value.leading_zeros() as i32 - 2;
 
-        tmp_value <<= MAX_STREAM_BITS - stream_bits - 1;
-        if (tmp_value & (1 << (MAX_STREAM_BITS - 1))) != 0 {
+        tmp_value <<= MAX_STREAM_BITS - stream_bits;
+        if (tmp_value & (1 << MAX_STREAM_BITS)) != 0 {
             self.carry();
         }
 
-        tmp_value <<= 1;
         let mut shift = MAX_STREAM_BITS - 8;
         let mut stream_bytes = (stream_bits + 7) >> 3;
         while stream_bytes > 0 {

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -28,10 +28,14 @@ use crate::metrics::{Metrics, ModelComponent};
 use crate::structs::branch::Branch;
 use crate::structs::simple_hash::SimpleHash;
 
+// MAX_STREAM_BITS should be a multiple of 8 and
+// (MAX_STREAM_BITS + 1 bit of carry + 1 bit of divider)
+// should fit into 64 bits of `low_value`
+const MAX_STREAM_BITS: i32 = 56; //48; //40;// 32;// 24;// 16;//
+
 pub struct VPXBoolWriter<W> {
-    low_value: u32,
+    low_value: u64,
     range: u32,
-    count: i32,
     writer: W,
     buffer: Vec<u8>,
     model_statistics: Metrics,
@@ -42,9 +46,8 @@ pub struct VPXBoolWriter<W> {
 impl<W: Write> VPXBoolWriter<W> {
     pub fn new(writer: W) -> Result<Self> {
         let mut retval = VPXBoolWriter {
-            low_value: 0,
+            low_value: 1 << 9, // this divider bit keeps track of stream bits number
             range: 255,
-            count: -24,
             buffer: Vec::new(),
             writer: writer,
             model_statistics: Metrics::default(),
@@ -67,9 +70,8 @@ impl<W: Write> VPXBoolWriter<W> {
         &mut self,
         value: bool,
         branch: &mut Branch,
-        tmp_value: &mut u32,
+        tmp_value: &mut u64,
         tmp_range: &mut u32,
-        tmp_count: &mut i32,
         _cmp: ModelComponent,
     ) -> Result<()> {
         #[cfg(feature = "detailed_tracing")]
@@ -77,7 +79,6 @@ impl<W: Write> VPXBoolWriter<W> {
             // used to detect divergences between the C++ and rust versions
             self.hash.hash(branch.get_u64());
             self.hash.hash(*tmp_value);
-            self.hash.hash(*tmp_count);
             self.hash.hash(*tmp_range);
 
             let hashed_value = self.hash.get();
@@ -98,7 +99,7 @@ impl<W: Write> VPXBoolWriter<W> {
         branch.record_and_update_bit(value);
 
         if value {
-            *tmp_value += split;
+            *tmp_value += split as u64;
             *tmp_range -= split;
         } else {
             *tmp_range = split;
@@ -113,22 +114,28 @@ impl<W: Write> VPXBoolWriter<W> {
         }
 
         *tmp_range <<= shift;
-        *tmp_count += shift;
 
-        if *tmp_count >= 0 {
-            let offset = shift - *tmp_count - 1;
-
-            *tmp_value <<= offset;
-            if (*tmp_value & 0x80000000) != 0 {
+        // check whether we have more than MAX_STREAM_BITS stream bits after shift
+        let stream_bits = 64 - (*tmp_value).leading_zeros() as i32 - 2;
+        let count = shift + stream_bits - MAX_STREAM_BITS;
+        if count >= 0 {
+            // check carry
+            *tmp_value <<= MAX_STREAM_BITS - stream_bits;
+            if (*tmp_value & (1 << MAX_STREAM_BITS)) != 0 {
                 self.carry();
             }
 
-            *tmp_value <<= 1;
-            self.buffer.push((*tmp_value >> 24) as u8);
-            *tmp_value &= 0xffffff;
+            let mut full_stream_bytes = (stream_bits >> 3) - 1;
+            let mut sh = MAX_STREAM_BITS - 8;
+            while full_stream_bytes > 0 {
+                self.buffer.push((*tmp_value >> sh) as u8);
+                sh -= 8;
+                full_stream_bytes -= 1;
+            }
+            *tmp_value &= (1 << (sh + 8)) - 1; // exclude written bytes
+            *tmp_value |= 1 << (sh + 9); // restore divider bit
 
-            shift = *tmp_count;
-            *tmp_count -= 8;
+            shift = count;
         }
 
         *tmp_value <<= shift;
@@ -165,7 +172,6 @@ impl<W: Write> VPXBoolWriter<W> {
         assert!((A & (A - 1)) == 0);
         let mut tmp_value = self.low_value;
         let mut tmp_range = self.range;
-        let mut tmp_count = self.count;
 
         let mut index = A.ilog2() - 1;
         let mut serialized_so_far = 1;
@@ -177,7 +183,6 @@ impl<W: Write> VPXBoolWriter<W> {
                 &mut branches[serialized_so_far],
                 &mut tmp_value,
                 &mut tmp_range,
-                &mut tmp_count,
                 cmp,
             )?;
 
@@ -193,7 +198,6 @@ impl<W: Write> VPXBoolWriter<W> {
 
         self.low_value = tmp_value;
         self.range = tmp_range;
-        self.count = tmp_count;
 
         Ok(())
     }
@@ -208,7 +212,6 @@ impl<W: Write> VPXBoolWriter<W> {
     ) -> Result<()> {
         let mut tmp_value = self.low_value;
         let mut tmp_range = self.range;
-        let mut tmp_count = self.count;
 
         let mut i: i32 = (num_bits - 1) as i32;
         while i >= 0 {
@@ -217,7 +220,6 @@ impl<W: Write> VPXBoolWriter<W> {
                 &mut branches[i as usize],
                 &mut tmp_value,
                 &mut tmp_range,
-                &mut tmp_count,
                 cmp,
             )?;
             i -= 1;
@@ -225,7 +227,6 @@ impl<W: Write> VPXBoolWriter<W> {
 
         self.low_value = tmp_value;
         self.range = tmp_range;
-        self.count = tmp_count;
 
         Ok(())
     }
@@ -241,7 +242,6 @@ impl<W: Write> VPXBoolWriter<W> {
 
         let mut tmp_value = self.low_value;
         let mut tmp_range = self.range;
-        let mut tmp_count = self.count;
 
         for i in 0..A {
             let cur_bit = v != i;
@@ -251,7 +251,6 @@ impl<W: Write> VPXBoolWriter<W> {
                 &mut branches[i],
                 &mut tmp_value,
                 &mut tmp_range,
-                &mut tmp_count,
                 cmp,
             )?;
             if !cur_bit {
@@ -261,7 +260,6 @@ impl<W: Write> VPXBoolWriter<W> {
 
         self.low_value = tmp_value;
         self.range = tmp_range;
-        self.count = tmp_count;
 
         Ok(())
     }
@@ -275,36 +273,34 @@ impl<W: Write> VPXBoolWriter<W> {
     ) -> Result<()> {
         let mut tmp_value = self.low_value;
         let mut tmp_range = self.range;
-        let mut tmp_count = self.count;
 
-        self.put(
-            value,
-            branch,
-            &mut tmp_value,
-            &mut tmp_range,
-            &mut tmp_count,
-            _cmp,
-        )?;
+        self.put(value, branch, &mut tmp_value, &mut tmp_range, _cmp)?;
 
         self.low_value = tmp_value;
         self.range = tmp_range;
-        self.count = tmp_count;
 
         Ok(())
     }
 
-    // Typically all bytes of `low_value` will have stream bits,
-    // so just write them all - that is what initial Lepton implementation does.
+    // Here we write down only bytes of the stream necessary for decoding -
+    // opposite to initial Lepton implementation that writes down all the buffer.
     pub fn finish(&mut self) -> Result<()> {
-        let tmp_value = self.low_value << (-self.count - 1);
+        let mut tmp_value = self.low_value;
+        let stream_bits = 64 - tmp_value.leading_zeros() as i32 - 2;
 
-        if (tmp_value & 0x80000000) != 0 {
+        tmp_value <<= MAX_STREAM_BITS - stream_bits - 1;
+        if (tmp_value & (1 << (MAX_STREAM_BITS - 1))) != 0 {
             self.carry();
         }
-        self.buffer.push((tmp_value >> 23) as u8);
-        self.buffer.push((tmp_value >> 15) as u8);
-        self.buffer.push((tmp_value >> 7) as u8);
-        self.buffer.push((tmp_value << 1) as u8);
+
+        tmp_value <<= 1;
+        let mut shift = MAX_STREAM_BITS - 8;
+        let mut stream_bytes = (stream_bits + 7) >> 3;
+        while stream_bytes > 0 {
+            self.buffer.push((tmp_value >> shift) as u8);
+            shift -= 8;
+            stream_bytes -= 1;
+        }
 
         self.writer.write_all(&self.buffer[..])?;
         Ok(())

--- a/src/structs/vpx_bool_writer.rs
+++ b/src/structs/vpx_bool_writer.rs
@@ -28,8 +28,8 @@ use crate::metrics::{Metrics, ModelComponent};
 use crate::structs::branch::Branch;
 use crate::structs::simple_hash::SimpleHash;
 
-// MAX_STREAM_BITS should be a multiple of 8 and
-// (MAX_STREAM_BITS + 1 bit of carry + 1 bit of divider)
+// MAX_STREAM_BITS should be a multiple of 8 larger than 8,
+// and (MAX_STREAM_BITS + 1 bit of carry + 1 bit of divider)
 // should fit into 64 bits of `low_value`
 const MAX_STREAM_BITS: i32 = 56; //48; //40;// 32;// 24;// 16;//
 
@@ -124,16 +124,14 @@ impl<W: Write> VPXBoolWriter<W> {
             if (*tmp_value & (1 << MAX_STREAM_BITS)) != 0 {
                 self.carry();
             }
-
-            let mut full_stream_bytes = (stream_bits >> 3) - 1;
+            // write all full bytes
             let mut sh = MAX_STREAM_BITS - 8;
-            while full_stream_bytes > 0 {
+            while sh > 0 {
                 self.buffer.push((*tmp_value >> sh) as u8);
                 sh -= 8;
-                full_stream_bytes -= 1;
             }
-            *tmp_value &= (1 << (sh + 8)) - 1; // exclude written bytes
-            *tmp_value |= 1 << (sh + 9); // restore divider bit
+            *tmp_value &= (1 << 8) - 1; // exclude written bytes
+            *tmp_value |= 1 << 9; // restore divider bit
 
             shift = count;
         }


### PR DESCRIPTION
This PR extends internal `low_value` buffer of bit writer and sends as many bytes as possible when number of stream bits in `low_value` exceeds MAX_STREAM_BITS. It gives substantial performance gain due to much better branch prediction on `if count >= 0` - now it is very rarely true.

Current `main`  7ee30b625d3ef7e3019345bc17d5d510395d1f8a
```
2024-11-16T21:36:50.846Z INFO  [lepton_jpeg::structs::lepton_file_writer] compressing to Lepton format
2024-11-16T21:36:51.329Z INFO  [lepton_jpeg::structs::lepton_file_writer] Number of threads: 8
2024-11-16T21:36:52.735Z INFO  [lepton_jpeg::structs::lepton_file_writer] worker threads 9667ms of CPU time in 1405ms of wall time
2024-11-16T21:36:52.735Z INFO  [lepton_jpeg::structs::lepton_file_writer] decompressing to verify contents
2024-11-16T21:36:54.336Z INFO  [lepton_jpeg_util] compressed input 22171278, output 17324076 bytes (compression = 28.0%)
2024-11-16T21:36:54.336Z INFO  [lepton_jpeg_util] Main thread CPU: 3489ms, Worker thread CPU: 20666 ms, walltime: 3489 ms

 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.jpg images/img_52MP_7k2.lep':

       872 864 510      cache-references                                                        (42,03%)
        81 345 085      cache-misses                     #    9,32% of all cache refs           (42,20%)
    15 679 683 044      cycles                                                                  (41,93%)
       844 619 245      ic_fetch_stall.ic_stall_back_pressure                                        (41,82%)
     1 127 999 657      stalled-cycles-frontend          #    7,19% frontend cycles idle        (41,57%)
    38 437 122 047      instructions                     #    2,45  insn per cycle            
                                                  #    0,03  stalled cycles per insn     (41,59%)
     4 360 833 730      branch-instructions                                                     (41,79%)
       164 653 082      branch-misses                    #    3,78% of all branches             (41,85%)
     5 188 234 309      ic_fetch_stall.ic_stall_any                                             (42,05%)
        36 892 099      ic_fetch_stall.ic_stall_dq_empty                                        (42,17%)
        68 333 545      l2_cache_misses_from_ic_miss                                            (42,13%)
     2 117 822 829      l2_latency.l2_cycles_waiting_on_fills                                        (42,01%)
           184 004      faults                                                                
                 1      migrations                                                            

       3,523626815 seconds time elapsed

       3,201068000 seconds user
       0,320906000 seconds sys
```
This PR 0426f91e1f2f98bcea07f7983fdb85f5cad3a2e5
```
2024-11-16T21:38:12.721Z INFO  [lepton_jpeg::structs::lepton_file_writer] compressing to Lepton format
2024-11-16T21:38:13.198Z INFO  [lepton_jpeg::structs::lepton_file_writer] Number of threads: 8
2024-11-16T21:38:14.474Z INFO  [lepton_jpeg::structs::lepton_file_writer] worker threads 8782ms of CPU time in 1274ms of wall time
2024-11-16T21:38:14.474Z INFO  [lepton_jpeg::structs::lepton_file_writer] decompressing to verify contents
2024-11-16T21:38:16.077Z INFO  [lepton_jpeg_util] compressed input 22171278, output 17324074 bytes (compression = 28.0%)
2024-11-16T21:38:16.077Z INFO  [lepton_jpeg_util] Main thread CPU: 3356ms, Worker thread CPU: 19835 ms, walltime: 3356 ms

 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.jpg images/img_52MP_7k2.lep':

       841 950 286      cache-references                                                        (42,16%)
        74 634 666      cache-misses                     #    8,86% of all cache refs           (41,91%)
    15 098 618 381      cycles                                                                  (41,72%)
       915 407 820      ic_fetch_stall.ic_stall_back_pressure                                        (41,58%)
       986 670 263      stalled-cycles-frontend          #    6,53% frontend cycles idle        (41,57%)
    38 910 234 032      instructions                     #    2,58  insn per cycle            
                                                  #    0,03  stalled cycles per insn     (41,53%)
     4 265 509 081      branch-instructions                                                     (41,82%)
       147 881 884      branch-misses                    #    3,47% of all branches             (42,01%)
     5 396 121 804      ic_fetch_stall.ic_stall_any                                             (42,07%)
        40 630 197      ic_fetch_stall.ic_stall_dq_empty                                        (42,20%)
        61 276 546      l2_cache_misses_from_ic_miss                                            (42,38%)
     2 181 284 237      l2_latency.l2_cycles_waiting_on_fills                                        (42,33%)
           184 036      faults                                                                
                 1      migrations                                                            

       3,391659429 seconds time elapsed

       3,064401000 seconds user
       0,323831000 seconds sys
```