### PR TITLE
improve command line utility

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,8 @@ jobs:
       run: cargo build --locked --target x86_64-pc-windows-msvc --lib
     - name: Run tests
       run: cargo test --locked
+    - name: Run tests (use_rayon)
+      run: cargo test --locked --features use_rayon
     - name: Check formatting
       run: cargo fmt --check
       

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        targets: wasm32-wasi,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu
+        targets: wasm32-wasi1,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu
         components: rustfmt,clippy
 
     - name: Build default target

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,13 +18,13 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         toolchain: stable
-        targets: wasm32-wasi1,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu
+        targets: wasm32-wasip1,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu
         components: rustfmt,clippy
 
     - name: Build default target
       run: cargo build --locked 
-    - name: Build wasm32-wasi
-      run: cargo build --locked --target wasm32-wasi --lib
+    - name: Build wasm32-wasip1
+      run: cargo build --locked --target wasm32-wasip1 --lib
     - name: Build aarch64-unknown-linux-musl
       run: cargo build --locked --target aarch64-unknown-linux-musl --lib
     - name: Build x86_64-pc-windows-msvc

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bytemuck"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
+checksum = "8b37c88a63ffd85d15b406896cc343916d7cf57838a847b3a6f2ca5d39a5695a"
 
 [[package]]
 name = "byteorder"
@@ -138,9 +138,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -202,7 +202,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -269,7 +269,7 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -280,9 +280,9 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 
 [[package]]
 name = "indexmap"
@@ -296,9 +296,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.11"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
 
 [[package]]
 name = "lazy_static"
@@ -317,6 +317,7 @@ dependencies = [
  "flate2",
  "git-version",
  "log",
+ "pico-args",
  "rand",
  "rand_chacha",
  "rayon-core",
@@ -330,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.159"
+version = "0.2.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "561d97a539a36e26a9a5fad1ea11a3039a67714694aaa379433e580854bc3dc5"
+checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
 
 [[package]]
 name = "log"
@@ -371,10 +372,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "pin-project-lite"
-version = "0.2.14"
+name = "pico-args"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -408,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -466,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -478,9 +485,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -525,7 +532,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version",
- "syn 2.0.79",
+ "syn 2.0.89",
  "unicode-ident",
 ]
 
@@ -540,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
 
 [[package]]
 name = "safe_arch"
@@ -561,22 +568,22 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.210"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -619,9 +626,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "44d46482f1c1c87acd84dea20c1bf5ebff4c757009ed6bf19cfd36fb10e92c4e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -630,9 +637,9 @@ dependencies = [
 
 [[package]]
 name = "thread-priority"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d3b04d33c9633b8662b167b847c7ab521f83d1ae20f2321b65b5b925e532e36"
+checksum = "cfe075d7053dae61ac5413a34ea7d4913b6e6207844fd726bdd858b37ff72bf5"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -694,9 +701,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unroll"
@@ -716,9 +723,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wide"
-version = "0.7.28"
+version = "0.7.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
+checksum = "58e6db2670d2be78525979e9a5f9c69d296fd7d670549fe9ebf70f8708cb5019"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -839,5 +846,5 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.89",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ simple_logger ="5.0"
 unroll = "0.1"
 rayon-core = { version = "1", optional = true }
 git-version = "0.3"
+pico-args = "0.5"
 
 [target.'cfg(windows)'.dependencies]
 cpu-time = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,13 @@ rayon-core = { version = "1", optional = true }
 git-version = "0.3"
 pico-args = "0.5"
 
-[target.'cfg(windows)'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 cpu-time = "1.0"
-thread-priority = "1.0.0"
+thread-priority = "1.0"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+cpu-time = "1.0"
+thread-priority = "1.0"
 
 [dev-dependencies]
 rstest = "0.22"

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -78,7 +78,7 @@ pub const MAX_THREADS: usize = 8;
 pub const RESIDUAL_NOISE_FLOOR: usize = 7;
 
 pub const LEPTON_VERSION: u8 = 1; // Lepton version, same as used by Lepton C++ since we support the same format
-pub const MAX_FILE_SIZE_BYTES: i32 = 128 * 1024 * 1024;
+
 //pub const LogMaxNumerator : i32 = 18;
 //pub const DefaultEncodingThreads : usize = 8;
 pub const SMALL_FILE_BYTES_PER_ENCDOING_THREAD: usize = 125000;

--- a/src/enabled_features.rs
+++ b/src/enabled_features.rs
@@ -24,6 +24,9 @@ pub struct EnabledFeatures {
 
     /// number of threads used for encoding/decoding
     pub max_threads: u32,
+
+    /// maximum size of a jpeg file
+    pub max_jpeg_file_size: u32,
 }
 
 impl EnabledFeatures {
@@ -39,6 +42,7 @@ impl EnabledFeatures {
             use_16bit_adv_predict: true,
             accept_invalid_dht: false,
             max_threads: 8,
+            max_jpeg_file_size: 128 * 1024 * 1024,
         }
     }
 
@@ -55,6 +59,7 @@ impl EnabledFeatures {
             use_16bit_adv_predict: false,
             accept_invalid_dht: true,
             max_threads: 8,
+            max_jpeg_file_size: 128 * 1024 * 1024,
         }
     }
 
@@ -71,6 +76,7 @@ impl EnabledFeatures {
             use_16bit_adv_predict: true,
             accept_invalid_dht: true,
             max_threads: 8,
+            max_jpeg_file_size: 128 * 1024 * 1024,
         }
     }
 }

--- a/src/lepton_error.rs
+++ b/src/lepton_error.rs
@@ -157,6 +157,15 @@ impl From<TryFromIntError> for LeptonError {
     }
 }
 
+impl From<pico_args::Error> for LeptonError {
+    #[track_caller]
+    fn from(e: pico_args::Error) -> Self {
+        let mut e = LeptonError::new(ExitCode::SyntaxError, e.to_string().as_str());
+        e.add_context();
+        e
+    }
+}
+
 impl<T> From<std::sync::mpsc::SendError<T>> for LeptonError {
     #[track_caller]
     fn from(e: std::sync::mpsc::SendError<T>) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub use metrics::Metrics;
 
 use crate::lepton_error::{AddContext, Result};
 
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 #[cfg(not(feature = "use_rayon"))]
 pub fn set_thread_priority(priority: thread_priority::ThreadPriority) {
     thread_priority::set_current_thread_priority(priority).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,19 @@ pub use metrics::Metrics;
 
 use crate::lepton_error::{AddContext, Result};
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
 #[cfg(not(feature = "use_rayon"))]
-pub fn set_thread_priority(priority: thread_priority::ThreadPriority) {
-    thread_priority::set_current_thread_priority(priority).unwrap();
-    crate::structs::simple_threadpool::set_thread_priority(priority);
+pub fn set_thread_priority(priority: i32) {
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    {
+        let p = match priority {
+            100 => thread_priority::ThreadPriority::Max,
+            0 => thread_priority::ThreadPriority::Min,
+            _ => panic!("Unsupported thread priority value: {}", priority),
+        };
+
+        thread_priority::set_current_thread_priority(p).unwrap();
+        crate::structs::simple_threadpool::set_thread_priority(p);
+    }
 }
 
 /// Decodes Lepton container and recreates the original JPEG file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,12 @@ pub use metrics::Metrics;
 
 use crate::lepton_error::{AddContext, Result};
 
+#[cfg(not(feature = "use_rayon"))]
+pub fn set_thread_priority(priority: thread_priority::ThreadPriority) {
+    thread_priority::set_current_thread_priority(priority).unwrap();
+    crate::structs::simple_threadpool::set_thread_priority(priority);
+}
+
 /// Decodes Lepton container and recreates the original JPEG file
 pub fn decode_lepton<R: BufRead, W: Write>(
     reader: &mut R,

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,6 +173,7 @@ Options:
         enabled_features.use_16bit_dc_estimate = false;
     }
 
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     if pargs.contains("--highpriority") {
         // used to force to run on p-cores, make sure this and
         // any threadpool threads are set to the highest priority
@@ -195,6 +196,7 @@ Options:
         }
     }
 
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
     if pargs.contains("--lowpriority") {
         // used to force to run on e-cores, make sure this and
         // any threadpool threads are set to the lowest priority

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,9 +4,12 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
+use std::borrow::Cow;
 use std::env;
-use std::fs::{File, OpenOptions};
+use std::ffi::OsStr;
+use std::fs::{remove_file, File, OpenOptions};
 use std::io::{stdin, stdout, Cursor, IsTerminal, Read, Seek, Write};
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
@@ -17,8 +20,6 @@ use lepton_jpeg::{
 };
 use log::{error, info};
 use simple_logger::SimpleLogger;
-#[cfg(all(target_os = "windows", feature = "use_rayon"))]
-use thread_priority::{set_current_thread_priority, ThreadPriority, WinAPIThreadPriority};
 
 #[derive(Copy, Clone, Debug)]
 enum FileType {
@@ -26,112 +27,219 @@ enum FileType {
     Lepton,
 }
 
+fn parse_i32(s: &str) -> Result<i32, &'static str> {
+    s.parse().map_err(|_| "not a number")
+}
+
+fn parse_u32(s: &str) -> Result<u32, &'static str> {
+    s.parse().map_err(|_| "not a number")
+}
+
+fn parse_u64(s: &str) -> Result<u64, &'static str> {
+    s.parse().map_err(|_| "not a number")
+}
+
+fn parse_path(s: &OsStr) -> Result<PathBuf, &'static str> {
+    Ok(PathBuf::from(s))
+}
+
+fn override_if<T>(
+    pargs: &mut pico_args::Arguments,
+    name: &'static str,
+    parse: fn(&str) -> Result<T, &'static str>,
+    value: &mut T,
+) -> Result<(), pico_args::Error> {
+    if let Some(v) = pargs.opt_value_from_fn(name, parse)? {
+        *value = v;
+    }
+    Ok(())
+}
+
 // wrap main so that errors get printed nicely without a panic
 fn main_with_result() -> Result<(), LeptonError> {
-    let args: Vec<String> = env::args().collect();
+    let mut pargs = pico_args::Arguments::from_env();
 
-    let mut verify_cpp = None;
-    let mut filenames = Vec::new();
-    let mut iterations = 1;
-    let mut dump = false;
-    let mut all = false;
-    let mut verify = true;
-    let mut overwrite = false;
     let mut enabled_features = EnabledFeatures::compat_lepton_vector_read();
-    let mut corrupt = false;
     let mut filter_level = log::LevelFilter::Info;
 
-    for i in 1..args.len() {
-        match *args[i].split(':').collect::<Vec<&str>>().as_slice() {
-            ["-verifycpp", cpp] => verify_cpp = Some(cpp.to_string()),
-            ["-iter", iter] => iterations = iter.parse::<i32>().unwrap(),
-            ["-max-width", width] => {
-                enabled_features.max_jpeg_width = width.parse::<i32>().unwrap()
-            }
-            ["-max-height", height] => {
-                enabled_features.max_jpeg_height = height.parse::<i32>().unwrap()
-            }
-            ["-threads", threads] => enabled_features.max_threads = threads.parse::<u32>().unwrap(),
-            // default is the most permissive compatible with the C++ SIMD version
-            ["-rejectprogressive"] => enabled_features.progressive = false,
-            ["-rejectdqtswithzeros"] => enabled_features.reject_dqts_with_zeros = true,
-            ["-rejectinvalidhuffman"] => enabled_features.accept_invalid_dht = false,
-            // use both these options if you are trying to read a file that was encoded with the scalar version of the C++ encoder
-            // sadly one old version of the Rust encoder used use_16bit_dc_estimate=false, use_16bit_adv_predict=true
-            // the latest version of the encoder put these options in the header so we ignore this if the file specifies it
-            ["-use32bitdc"] => enabled_features.use_16bit_dc_estimate = false,
-            ["-use32bitadv"] => enabled_features.use_16bit_adv_predict = false,
-            ["-useleptonscalar"] => {
-                // default option is the vector version, since Lepton usually will get to compiled to at least SSE2
-                enabled_features.use_16bit_adv_predict = false;
-                enabled_features.use_16bit_dc_estimate = false;
-            }
-            ["-overwrite"] => overwrite = true,
-            ["-dump"] => dump = true,
-            ["-all"] => all = true,
-            ["-corrupt"] => {
-                // randomly corrupt the files for testing
-                corrupt = true;
-            }
-            ["-noverify"] => verify = false,
-            ["-quiet"] => filter_level = log::LevelFilter::Warn,
-            ["-version"] => {
-                println!(
-                    "compiled library Lepton version {}, git revision: {}",
-                    env!("CARGO_PKG_VERSION"),
-                    git_version::git_version!(
-                        args = ["--abbrev=40", "--always", "--dirty=-modified"]
-                    )
-                );
-            }
-            ["-highpriority"] => {
-                // used to force to run on p-cores, make sure this and
-                // any threadpool threads are set to the high priority
+    if pargs.contains(["-h", "--help"]) {
+        println!(
+"lepton_jpeg_util - a fast JPEG compressor
 
-                #[cfg(all(target_os = "windows", feature = "use_rayon"))]
-                {
-                    let priority = ThreadPriority::Os(WinAPIThreadPriority::TimeCritical.into());
+Usage: lepton_jpeg_util [options] inputfile [outputfile]
 
-                    set_current_thread_priority(priority).unwrap();
+Options:
+    --iter <n>              number of iterations to run
+    --dump                  dump the JPEG file
+    --all                   dump includes the scan lines
+    --cppverify <exe path>  verify the output with the C++ encoder
+    --overwrite             overwrite the output file
+    --corrupt <seed>        randomly corrupt the input file (for testing)
+    --quiet                 suppress all output
+    --noverify              do not verify the output
+    --max-width <n>         maximum width of the JPEG file
+    --max-height <n>        maximum height of the JPEG file
+    --threads <n>           maximum number of threads to use
+    --rejectprogressive     reject progressive JPEG files
+    --rejectdqtswithzeros   reject DQT tables with zeros
+    --rejectinvalidhuffman  reject invalid Huffman tables
+    --use32bitdc            use 32 bit DC estimate
+    --use32bitadv           use 32 bit advanced prediction
+    --useleptonscalar       use the scalar version of the encoder
+    --highpriority          run on p-cores
+    --lowpriority           run on e-cores
+    --version               print the version
+    --help                  print this help message
+    --verifydir             Recursively verify all files in a directory can be compressed and decompressed
+");
+        return Ok(());
+    }
 
-                    let b = rayon_core::ThreadPoolBuilder::new();
-                    b.start_handler(move |_| {
-                        set_current_thread_priority(priority).unwrap();
-                    })
-                    .build_global()
-                    .unwrap();
-                }
-            }
-            ["-lowpriority"] => {
-                // used to force to run on e-cores, make sure this and
-                // any threadpool threads are set to the high priority
+    let cppverify: Option<PathBuf> = pargs.opt_value_from_os_str("--cppverify", parse_path)?;
+    let verify_dir = pargs.opt_value_from_os_str("--verifydir", parse_path)?;
 
-                #[cfg(all(target_os = "windows", feature = "use_rayon"))]
-                {
-                    let priority = ThreadPriority::Os(WinAPIThreadPriority::Idle.into());
+    let iterations = pargs.opt_value_from_fn("--iter", parse_i32)?.unwrap_or(1);
+    let dump = pargs.contains("--dump");
+    let dumpall = pargs.contains("--dumpall");
+    let verify = !pargs.contains("--noverify");
+    let overwrite = pargs.contains("--overwrite");
+    let mut corrupt = pargs.opt_value_from_fn("--corrupt", parse_u64)?;
 
-                    set_current_thread_priority(priority).unwrap();
+    if pargs.contains("--quiet") {
+        filter_level = log::LevelFilter::Warn;
+    }
 
-                    let b = rayon_core::ThreadPoolBuilder::new();
-                    b.start_handler(move |_| {
-                        set_current_thread_priority(priority).unwrap();
-                    })
-                    .build_global()
-                    .unwrap();
-                }
-            }
-            _ => {
-                if args[i].starts_with("-") {
-                    return Err(LeptonError::new(
-                        ExitCode::SyntaxError,
-                        format!("unknown switch {0}", args[i]).as_str(),
-                    )
-                    .into());
-                } else {
-                    filenames.push(args[i].as_str());
-                }
-            }
+    override_if(
+        &mut pargs,
+        "--max-width",
+        parse_i32,
+        &mut enabled_features.max_jpeg_width,
+    )?;
+
+    override_if(
+        &mut pargs,
+        "--max-height",
+        parse_i32,
+        &mut enabled_features.max_jpeg_height,
+    )?;
+
+    override_if(
+        &mut pargs,
+        "--threads",
+        parse_u32,
+        &mut enabled_features.max_threads,
+    )?;
+
+    override_if(
+        &mut pargs,
+        "--rejectprogressive",
+        |_| Ok(false),
+        &mut enabled_features.progressive,
+    )?;
+
+    override_if(
+        &mut pargs,
+        "--rejectdqtswithzeros",
+        |_| Ok(true),
+        &mut enabled_features.reject_dqts_with_zeros,
+    )?;
+
+    override_if(
+        &mut pargs,
+        "--rejectinvalidhuffman",
+        |_| Ok(false),
+        &mut enabled_features.accept_invalid_dht,
+    )?;
+
+    if pargs.contains("--version") {
+        println!(
+            "compiled library Lepton version {}, git revision: {}",
+            env!("CARGO_PKG_VERSION"),
+            git_version::git_version!(args = ["--abbrev=40", "--always", "--dirty=-modified"])
+        );
+    }
+
+    if pargs.contains("--use32bitdc") {
+        enabled_features.use_16bit_dc_estimate = false;
+    }
+    if pargs.contains("--use32bitadv") {
+        enabled_features.use_16bit_adv_predict = false;
+    }
+    if pargs.contains("--useleptonscalar") {
+        // use both these options if you are trying to read a file that was encoded with the scalar version of the C++ encoder
+        // sadly one old version of the Rust encoder used use_16bit_dc_estimate=false, use_16bit_adv_predict=true
+        // the latest version of the encoder put these options in the header so we ignore this if the file specifies it
+        enabled_features.use_16bit_adv_predict = false;
+        enabled_features.use_16bit_dc_estimate = false;
+    }
+
+    if pargs.contains("--highpriority") {
+        // used to force to run on p-cores, make sure this and
+        // any threadpool threads are set to the highest priority
+        #[cfg(feature = "use_rayon")]
+        {
+            let priority = ThreadPriority::Os(thread_priority::ThreadPriority::Max);
+
+            set_current_thread_priority(priority).unwrap();
+
+            let b = rayon_core::ThreadPoolBuilder::new();
+            b.start_handler(move |_| {
+                set_current_thread_priority(priority).unwrap();
+            })
+            .build_global()
+            .unwrap();
         }
+        #[cfg(not(feature = "use_rayon"))]
+        {
+            lepton_jpeg::set_thread_priority(thread_priority::ThreadPriority::Max);
+        }
+    }
+
+    if pargs.contains("--lowpriority") {
+        // used to force to run on e-cores, make sure this and
+        // any threadpool threads are set to the lowest priority
+        #[cfg(feature = "use_rayon")]
+        {
+            let priority = ThreadPriority::Os(thread_priority::ThreadPriority::Min);
+
+            set_current_thread_priority(priority).unwrap();
+
+            let b = rayon_core::ThreadPoolBuilder::new();
+            b.start_handler(move |_| {
+                set_current_thread_priority(priority).unwrap();
+            })
+            .build_global()
+            .unwrap();
+        }
+        #[cfg(not(feature = "use_rayon"))]
+        {
+            lepton_jpeg::set_thread_priority(thread_priority::ThreadPriority::Min);
+        }
+    }
+
+    let filenames = pargs.finish();
+
+    for i in filenames.iter() {
+        // no other options should be specified only the free standing filenames
+        if i.to_string_lossy().starts_with("-") {
+            return Err(LeptonError::new(
+                ExitCode::SyntaxError,
+                format!("unknown option {:?}", i).as_str(),
+            )
+            .into());
+        }
+    }
+
+    // if we are verifying a directory, then we need to recursively verify all files in the directory
+    if let Some(verify_dir) = verify_dir {
+        execute_verify_dir(
+            &cppverify,
+            &verify_dir.as_path(),
+            &enabled_features,
+            verify,
+            &mut corrupt,
+        )?;
+        return Ok(());
     }
 
     // only output the log if we are connected to a console (otherwise if there is redirection we would corrupt the file)
@@ -140,11 +248,11 @@ fn main_with_result() -> Result<(), LeptonError> {
     }
 
     if dump {
-        let mut file_in = File::open(filenames[0]).unwrap();
+        let mut file_in = File::open(filenames[0].as_os_str()).unwrap();
 
         let mut contents = Vec::new();
         file_in.read_to_end(&mut contents).unwrap();
-        dump_jpeg(&contents, all, &enabled_features).unwrap();
+        dump_jpeg(&contents, dumpall, &enabled_features).unwrap();
         return Ok(());
     }
 
@@ -160,7 +268,7 @@ fn main_with_result() -> Result<(), LeptonError> {
 
         std::io::stdin().read_to_end(&mut input_data)?;
     } else {
-        let mut file_in = File::open(filenames[0])
+        let mut file_in = File::open(filenames[0].as_os_str())
             .map_err(|e| LeptonError::new(ExitCode::FileNotFound, e.to_string().as_str()))?;
 
         file_in.read_to_end(&mut input_data)?;
@@ -172,23 +280,10 @@ fn main_with_result() -> Result<(), LeptonError> {
 
     let mut metrics;
     let mut output_data;
-    let mut original_data = Vec::new();
-
-    // save the data if we are going to corrupt it
-    if corrupt {
-        original_data = input_data.clone();
-    }
 
     let mut overall_cpu = Duration::ZERO;
 
     let mut current_iteration = 0;
-
-    let mut seed = 0x123456789abcdef0;
-    fn simple_lcg(seed: &mut u64) -> u64 {
-        let r = seed.wrapping_mul(6364136223846793005) + 1;
-        *seed = r;
-        r
-    }
 
     // see what file type we have
     let file_type = if input_data[0] == 0xff && input_data[1] == 0xd8 {
@@ -203,28 +298,26 @@ fn main_with_result() -> Result<(), LeptonError> {
         .into());
     };
 
+    // get a writable version of the input data so we can corrupt it if the user wants to
+    let mut writable_input_data = Cow::from(&input_data);
+
     loop {
         let thread_cpu = CpuTimeMeasure::new();
         let walltime = Instant::now();
 
-        if corrupt {
-            let r = simple_lcg(&mut seed) as usize % input_data.len();
-
-            let bitnumber = simple_lcg(&mut seed) as usize % 8;
-
-            input_data[r] ^= 1 << bitnumber;
-        }
+        corrupt_data_if_enabled(&mut corrupt, &mut writable_input_data.to_mut());
 
         // do the encoding/decoding, if we got an error and were corrupting the file, then restore the
         // original data and continue so we can try corrupting the file in different ways
         // per iteration
-        match do_work(file_type, verify, &input_data, &enabled_features) {
+        match do_work(file_type, verify, &writable_input_data, &enabled_features) {
             Err(e) => {
                 error!("error {0}", e);
 
                 // if we corrupted the image, then restore and continue running
-                if corrupt {
-                    input_data = original_data.clone();
+                if corrupt.is_some() {
+                    // reset the input data not be be corrupt anymore
+                    writable_input_data = Cow::from(&input_data);
                     output_data = Vec::new();
                     metrics = Metrics::default();
                 } else {
@@ -259,54 +352,23 @@ fn main_with_result() -> Result<(), LeptonError> {
     if filenames.len() != 2 {
         std::io::stdout().write_all(&output_data[..])?
     } else {
-        let output_file: String = filenames[1].to_owned();
+        let output_filename = filenames[1].as_os_str();
 
-        let o = output_file.as_str();
         let mut fileout = OpenOptions::new()
             .write(true)
             .create(overwrite)
             .create_new(!overwrite)
-            .open(o)?;
+            .open(output_filename)?;
 
-        fileout.set_len(output_data.len() as u64)?;
+        // ignore if this failed (etc on a pipe)
+        let _ = fileout.set_len(output_data.len() as u64);
         fileout.write_all(&output_data[..])?;
         drop(fileout);
 
         // what we do is take the lepton output, and see if it recreates the input using the
         // CPP version of the encoder/decoder
-        if let Some(v) = verify_cpp {
-            let (output, exit_code, stderr) = call_executable_with_input(v.as_str(), o)?;
-            if exit_code != 0 {
-                log::error!("cpp exit code: {}", exit_code);
-
-                return Err(LeptonError::new(
-                    ExitCode::ExternalVerificationFailed,
-                    format!(
-                        "verify failed with exit code {0} stderr: {1}",
-                        exit_code, stderr
-                    )
-                    .as_str(),
-                ))?;
-            }
-            if output[..].len() != input_data.len() {
-                return Err(LeptonError::new(
-                    ExitCode::ExternalVerificationFailed,
-                    format!(
-                        "verify failed with different length {0} != {1}",
-                        output[..].len(),
-                        input_data.len()
-                    )
-                    .as_str(),
-                ));
-            }
-            if output[..] != input_data[..] {
-                return Err(LeptonError::new(
-                    ExitCode::ExternalVerificationFailed,
-                    "verify failed with different data",
-                )
-                .into());
-            }
-            log::info!("verify succeeded with cpp version");
+        if let Some(cpp_path) = cppverify {
+            execute_cpp_verify(cpp_path.as_path(), output_filename, &writable_input_data)?;
         }
     }
 
@@ -320,11 +382,165 @@ fn main_with_result() -> Result<(), LeptonError> {
     Ok(())
 }
 
+/// randomly corrupts data if there is a seed
+fn corrupt_data_if_enabled(seed: &mut Option<u64>, input_data: &mut Vec<u8>) {
+    fn simple_lcg(seed: &mut u64) -> u64 {
+        let r = seed.wrapping_mul(6364136223846793005) + 1;
+        *seed = r;
+        r
+    }
+
+    if let Some(seed) = seed {
+        if input_data.len() > 0 {
+            let r = simple_lcg(seed) as usize % input_data.len();
+
+            let bitnumber = simple_lcg(seed) as usize % 8;
+
+            input_data[r] ^= 1 << bitnumber;
+        }
+    }
+}
+
+/// recursively verify all files in a directory, including potentially verifying it with the CPP version of the decoder
+/// to make sure that we didn't break the format in some unexpected way
+fn execute_verify_dir(
+    cpp_executable: &Option<PathBuf>,
+    dir: &Path,
+    enabled_features: &EnabledFeatures,
+    verify: bool,
+    corrupt_data_seed: &mut Option<u64>,
+) -> Result<(), LeptonError> {
+    let entries;
+    match std::fs::read_dir(dir) {
+        Ok(e) => entries = e,
+        Err(e) => {
+            eprintln!("error reading directory {:?} {:?}", dir, e);
+            return Ok(());
+        }
+    }
+
+    for entry in entries {
+        let entry = entry.unwrap();
+        let path = entry.path();
+
+        if path.is_dir() {
+            execute_verify_dir(
+                cpp_executable,
+                &path,
+                enabled_features,
+                verify,
+                corrupt_data_seed,
+            )?;
+            continue;
+        }
+
+        if let Some(x) = path.extension() {
+            if x != "jpg" && x != "jpeg" {
+                continue;
+            }
+
+            let mut file_in;
+            match File::open(&path) {
+                Ok(f) => file_in = f,
+                Err(e) => {
+                    eprintln!("error reading file {:?} {:?}", path, e);
+                    continue;
+                }
+            }
+
+            let mut original_contents = Vec::new();
+            file_in.read_to_end(&mut original_contents).unwrap();
+
+            corrupt_data_if_enabled(corrupt_data_seed, &mut original_contents);
+
+            match do_work(
+                FileType::Jpeg,
+                verify,
+                &original_contents,
+                &enabled_features,
+            ) {
+                Err(e) => {
+                    eprintln!("{:?} error {}", path, e);
+                }
+                Ok((output, _)) => {
+                    if let Some(cpp_executable) = cpp_executable {
+                        // create the input file for the lepton C++ decoder
+                        let verify_output = std::env::temp_dir().join("lepton_jpeg_util_cpp.lep");
+
+                        let mut file_out = File::create(&verify_output).unwrap();
+                        file_out.write_all(&output[..]).unwrap();
+                        drop(file_out);
+
+                        let r = execute_cpp_verify(
+                            cpp_executable,
+                            verify_output.as_os_str(),
+                            &original_contents,
+                        );
+                        let _ = remove_file(verify_output);
+                        if r.is_err() {
+                            eprintln!("{:?} CPP_VERIFY error {:?}", path, r);
+                            if let Some(s) = corrupt_data_seed {
+                                eprintln!("corruption seed was {0}", s);
+                            }
+                            // abort here, this is bad
+                            return r;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn execute_cpp_verify(
+    cpp_executable: &Path,
+    compressed_file: &OsStr,
+    original_contents: &[u8],
+) -> Result<(), LeptonError> {
+    let (output, exit_code, stderr) =
+        call_executable_with_input(cpp_executable, compressed_file).unwrap();
+
+    if exit_code != 0 {
+        log::error!("cpp exit code: {}", exit_code);
+
+        return Err(LeptonError::new(
+            ExitCode::ExternalVerificationFailed,
+            format!(
+                "cpp verify failed with exit code {0} stderr: {1}",
+                exit_code, stderr
+            )
+            .as_str(),
+        ))?;
+    }
+    if output[..].len() != original_contents.len() {
+        return Err(LeptonError::new(
+            ExitCode::ExternalVerificationFailed,
+            format!(
+                "cpp verify failed with different length {0} != {1}",
+                output[..].len(),
+                original_contents.len()
+            )
+            .as_str(),
+        ));
+    }
+    if output[..] != original_contents[..] {
+        return Err(LeptonError::new(
+            ExitCode::ExternalVerificationFailed,
+            "verify failed with different data",
+        )
+        .into());
+    }
+    log::info!("verify succeeded with cpp version");
+    Ok(())
+}
+
 /// does the actual encoding/decoding work
 fn do_work(
     file_type: FileType,
     verify: bool,
-    input_data: &Vec<u8>,
+    input_data: &[u8],
     enabled_features: &EnabledFeatures,
 ) -> Result<(Vec<u8>, Metrics), LeptonError> {
     let metrics;
@@ -428,28 +644,30 @@ fn main() {
     }
 }
 
+/// calls the CPP version of the encoder/decoder to verify the output of the Rust version
 pub fn call_executable_with_input(
-    executable: &str,
-    input_filename: &str,
+    cpp_executable: &Path,
+    input_filename: &OsStr,
 ) -> Result<(Vec<u8>, i32, String), LeptonError> {
     // temporary file to store the output of the cpp version so we can
     // compare it with the rust version
-    let v = format!("{0}.verify", input_filename);
-    let verify_filename = v.as_str();
+
+    let temp_filename_buf = std::env::temp_dir().join("lepton_jpeg_util_cpp_recreate.jpg");
+    let temp_filename = temp_filename_buf.as_os_str();
 
     // delete if already exists
-    let _ = std::fs::remove_file(verify_filename);
+    let _ = std::fs::remove_file(temp_filename);
 
     log::info!(
-        "verifying input filename {} with {}",
-        input_filename,
-        executable
+        "verifying input filename with CPP {:?} with {:?}",
+        temp_filename,
+        cpp_executable
     );
 
     // Spawn the command
-    let child = Command::new(executable)
+    let child = Command::new(cpp_executable)
         .arg(input_filename)
-        .arg(verify_filename)
+        .arg(temp_filename)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
@@ -457,12 +675,12 @@ pub fn call_executable_with_input(
     // Wait for the child process to exit and collect output
     let output = child.wait_with_output()?;
 
-    let mut file_in = File::open(verify_filename).unwrap();
+    let mut file_in = File::open(&temp_filename).unwrap();
     let mut contents = Vec::new();
     file_in.read_to_end(&mut contents).unwrap();
 
     // remove the temporary file
-    let _ = std::fs::remove_file(verify_filename);
+    let _ = std::fs::remove_file(temp_filename);
 
     // Extract the stdout, stderr, and exit status
     let stderr = String::from_utf8_lossy(&output.stderr).to_string();

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,6 +79,7 @@ Options:
     --noverify              do not verify the output
     --max-width <n>         maximum width of the JPEG file
     --max-height <n>        maximum height of the JPEG file
+    --max-jpeg-file-size <n> maximum size of the JPEG file
     --threads <n>           maximum number of threads to use
     --rejectprogressive     reject progressive JPEG files
     --rejectdqtswithzeros   reject DQT tables with zeros
@@ -149,6 +150,13 @@ Options:
         "--rejectinvalidhuffman",
         |_| Ok(false),
         &mut enabled_features.accept_invalid_dht,
+    )?;
+
+    override_if(
+        &mut pargs,
+        "--max-jpeg-file-size",
+        parse_u32,
+        &mut enabled_features.max_jpeg_file_size,
     )?;
 
     if pargs.contains("--version") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -72,7 +72,7 @@ Options:
     --iter <n>              number of iterations to run
     --dump                  dump the JPEG file
     --all                   dump includes the scan lines
-    --cppverify <exe path>  verify the output with the C++ encoder
+    --cppverify <exe path>  verify the output with the C++ decoder
     --overwrite             overwrite the output file
     --corrupt <seed>        randomly corrupt the input file (for testing)
     --quiet                 suppress all output

--- a/src/main.rs
+++ b/src/main.rs
@@ -173,50 +173,18 @@ Options:
         enabled_features.use_16bit_dc_estimate = false;
     }
 
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(not(feature = "use_rayon"))]
     if pargs.contains("--highpriority") {
         // used to force to run on p-cores, make sure this and
         // any threadpool threads are set to the highest priority
-        #[cfg(feature = "use_rayon")]
-        {
-            let priority = ThreadPriority::Os(thread_priority::ThreadPriority::Max);
-
-            set_current_thread_priority(priority).unwrap();
-
-            let b = rayon_core::ThreadPoolBuilder::new();
-            b.start_handler(move |_| {
-                set_current_thread_priority(priority).unwrap();
-            })
-            .build_global()
-            .unwrap();
-        }
-        #[cfg(not(feature = "use_rayon"))]
-        {
-            lepton_jpeg::set_thread_priority(thread_priority::ThreadPriority::Max);
-        }
+        lepton_jpeg::set_thread_priority(100);
     }
 
-    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    #[cfg(not(feature = "use_rayon"))]
     if pargs.contains("--lowpriority") {
         // used to force to run on e-cores, make sure this and
         // any threadpool threads are set to the lowest priority
-        #[cfg(feature = "use_rayon")]
-        {
-            let priority = ThreadPriority::Os(thread_priority::ThreadPriority::Min);
-
-            set_current_thread_priority(priority).unwrap();
-
-            let b = rayon_core::ThreadPoolBuilder::new();
-            b.start_handler(move |_| {
-                set_current_thread_priority(priority).unwrap();
-            })
-            .build_global()
-            .unwrap();
-        }
-        #[cfg(not(feature = "use_rayon"))]
-        {
-            lepton_jpeg::set_thread_priority(thread_priority::ThreadPriority::Min);
-        }
+        lepton_jpeg::set_thread_priority(0);
     }
 
     let filenames = pargs.finish();

--- a/src/structs/lepton_file_writer.rs
+++ b/src/structs/lepton_file_writer.rs
@@ -257,6 +257,14 @@ pub fn read_jpeg<R: Read + Seek>(
         split_row_handoffs_to_threads(&thread_handoff[..], enabled_features.max_threads as usize);
     lp.thread_handoff = merged_handoffs;
     lp.jpeg_file_size = reader.stream_position().context()? as u32;
+
+    if lp.jpeg_file_size > enabled_features.max_jpeg_file_size {
+        return err_exit_code(
+            ExitCode::UnsupportedJpeg,
+            "file is too large to encode, increase max_jpeg_file_size",
+        );
+    }
+
     Ok((lp, image_data))
 }
 

--- a/src/structs/lepton_header.rs
+++ b/src/structs/lepton_header.rs
@@ -146,11 +146,18 @@ impl LeptonHeader {
         enabled_features: &mut EnabledFeatures,
         compressed_header_size: usize,
     ) -> Result<()> {
-        if compressed_header_size > MAX_FILE_SIZE_BYTES as usize {
+        if compressed_header_size > enabled_features.max_jpeg_file_size as usize {
             return err_exit_code(ExitCode::BadLeptonFile, "Too big compressed header");
         }
-        if self.jpeg_file_size > MAX_FILE_SIZE_BYTES as u32 {
-            return err_exit_code(ExitCode::BadLeptonFile, "Only support images < 128 megs");
+        if self.jpeg_file_size > enabled_features.max_jpeg_file_size {
+            return err_exit_code(
+                ExitCode::BadLeptonFile,
+                format!(
+                    "Only support images < {} megs",
+                    enabled_features.max_jpeg_file_size / (1024 * 1024)
+                )
+                .as_str(),
+            );
         }
 
         // limit reading to the compressed header

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -34,7 +34,7 @@ mod row_spec;
 mod simple_hash;
 
 #[cfg(not(feature = "use_rayon"))]
-mod simple_threadpool;
+pub mod simple_threadpool;
 
 mod thread_handoff;
 mod truncate_components;

--- a/src/structs/simple_threadpool.rs
+++ b/src/structs/simple_threadpool.rs
@@ -24,6 +24,8 @@ use thread_priority::ThreadPriority;
 static IDLE_THREADS: LazyLock<Mutex<Vec<Sender<Box<dyn FnOnce() + Send + 'static>>>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 static NUM_CPUS: LazyLock<usize> = LazyLock::new(|| thread::available_parallelism().unwrap().get());
+
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 static THREAD_PRIORITY: Mutex<Option<ThreadPriority>> = Mutex::new(None);
 
 #[allow(dead_code)]
@@ -31,6 +33,7 @@ pub fn get_idle_threads() -> usize {
     IDLE_THREADS.lock().unwrap().len()
 }
 
+#[cfg(any(target_os = "windows", target_os = "linux"))]
 #[allow(dead_code)]
 pub fn set_thread_priority(priority: ThreadPriority) {
     *THREAD_PRIORITY.lock().unwrap() = Some(priority);

--- a/src/structs/simple_threadpool.rs
+++ b/src/structs/simple_threadpool.rs
@@ -19,13 +19,21 @@ use std::{
     thread::{self, spawn},
 };
 
+use thread_priority::ThreadPriority;
+
 static IDLE_THREADS: LazyLock<Mutex<Vec<Sender<Box<dyn FnOnce() + Send + 'static>>>>> =
     LazyLock::new(|| Mutex::new(Vec::new()));
 static NUM_CPUS: LazyLock<usize> = LazyLock::new(|| thread::available_parallelism().unwrap().get());
+static THREAD_PRIORITY: Mutex<Option<ThreadPriority>> = Mutex::new(None);
 
 #[allow(dead_code)]
 pub fn get_idle_threads() -> usize {
     IDLE_THREADS.lock().unwrap().len()
+}
+
+#[allow(dead_code)]
+pub fn set_thread_priority(priority: ThreadPriority) {
+    *THREAD_PRIORITY.lock().unwrap() = Some(priority);
 }
 
 /// Executes a closure on a thread from the thread pool. Does not block or return any result.
@@ -39,7 +47,13 @@ where
         // channel for receiving future work on this thread
         let (tx_schedule, rx_schedule) = channel();
 
+        let thread_priority = THREAD_PRIORITY.lock().unwrap().clone();
+
         spawn(move || {
+            if let Some(priority) = thread_priority {
+                thread_priority::set_current_thread_priority(priority).unwrap();
+            }
+
             f();
 
             loop {


### PR DESCRIPTION
- Use a real, but tiny argument parser (unfortunately this means all the switches now get -- as per unix standard)
- Add option to scan a whole directory and verify that the compressor works
- Include the option to run cpp version of lepton to verify that the files are all decompressable by the standard version
