### PR TITLE
Optimize devli to speed up jpeg reading

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -93,12 +93,12 @@ pub fn buffer_prefix_matches_marker<const BS: usize, const MS: usize>(
 
 #[inline(always)]
 pub const fn devli(s: u8, value: u16) -> i16 {
-    if s == 0 {
+    let shifted = 1 << s;
+
+    if value >= (shifted >> 1) {
         value as i16
-    } else if value < (1 << (s as u16 - 1)) {
-        value as i16 + (-1 << s as i16) + 1
     } else {
-        value as i16
+        (value + !(shifted - 1) + 1) as i16
     }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -102,6 +102,25 @@ pub const fn devli(s: u8, value: u16) -> i16 {
     }
 }
 
+/// check to make sure the behavior hasn't changed even with the optimization
+#[test]
+fn devli_test() {
+    for s in 0u8..15 {
+        for value in 0..(1 << s) {
+            assert_eq!(
+                devli(s, value) as i16,
+                if s == 0 {
+                    value as i16
+                } else if value < (1 << (s as u16 - 1)) {
+                    value as i16 + (-1 << s as i16) + 1
+                } else {
+                    value as i16
+                }
+            );
+        }
+    }
+}
+
 #[inline(always)]
 pub const fn b_short(v1: u8, v2: u8) -> u16 {
     ((v1 as u16) << 8) + v2 as u16


### PR DESCRIPTION
The function contributes about 1.3% on the write path (with no verify) and this speeds it up by a factor of 2.