### PR TITLE
Draft: Faster devli

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -102,10 +102,10 @@ pub fn has_ff(v: u64) -> bool {
 pub const fn devli(s: u8, value: u16) -> i16 {
     let shifted = 1 << s;
 
-    if value >= (shifted >> 1) {
+    if value & (shifted >> 1) != 0 {
         value as i16
     } else {
-        (value + !(shifted - 1) + 1) as i16
+        (value + !shifted + 2) as i16
     }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -105,7 +105,7 @@ pub const fn devli(s: u8, value: u16) -> i16 {
     if value & (shifted >> 1) != 0 {
         value as i16
     } else {
-        (!shifted + 2 + value) as i16
+        value.wrapping_add(2).wrapping_add(!shifted) as i16
     }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -105,7 +105,7 @@ pub const fn devli(s: u8, value: u16) -> i16 {
     if value & (shifted >> 1) != 0 {
         value as i16
     } else {
-        (value + !shifted + 2) as i16
+        (!shifted + 2 + value) as i16
     }
 }
 


### PR DESCRIPTION
This one is even faster.
This PR:
```
2024-11-28T16:29:18.893Z INFO  [lepton_jpeg::structs::lepton_file_writer] compressing to Lepton format
2024-11-28T16:29:19.208Z INFO  [lepton_jpeg::structs::lepton_file_writer] Number of threads: 8
2024-11-28T16:29:20.368Z INFO  [lepton_jpeg::structs::lepton_file_writer] worker threads 7858ms of CPU time in 1159ms of wall time
2024-11-28T16:29:20.368Z INFO  [lepton_jpeg::structs::lepton_file_writer] decompressing to verify contents
2024-11-28T16:29:21.964Z INFO  [lepton_jpeg_util] compressed input 22171278, output 17324074 bytes (compression = 28.0%)
2024-11-28T16:29:21.964Z INFO  [lepton_jpeg_util] Main thread CPU: 3079ms, Worker thread CPU: 18932 ms, walltime: 3079 ms

 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.jpg images/img_52MP_7k2.lep':

       856 356 180      cache-references                                                        (41,98%)
        77 370 996      cache-misses                     #    9,03% of all cache refs           (42,01%)
    13 993 059 542      cycles                                                                  (42,14%)
       867 635 268      ic_fetch_stall.ic_stall_back_pressure                                        (41,96%)
       941 433 323      stalled-cycles-frontend          #    6,73% frontend cycles idle        (42,00%)
    35 972 608 610      instructions                     #    2,57  insn per cycle            
                                                  #    0,03  stalled cycles per insn     (41,97%)
     3 714 314 164      branch-instructions                                                     (41,94%)
       128 908 676      branch-misses                    #    3,47% of all branches             (42,04%)
     5 185 255 540      ic_fetch_stall.ic_stall_any                                             (41,97%)
        45 834 143      ic_fetch_stall.ic_stall_dq_empty                                        (41,66%)
        64 656 701      l2_cache_misses_from_ic_miss                                            (41,54%)
     2 105 824 228      l2_latency.l2_cycles_waiting_on_fills                                        (41,81%)
           188 685      faults                                                                
                 1      migrations                                                            

       3,114311487 seconds time elapsed

       2,781031000 seconds user
       0,329648000 seconds sys
```
`main`
```
2024-11-28T16:35:22.831Z INFO  [lepton_jpeg::structs::lepton_file_writer] compressing to Lepton format
2024-11-28T16:35:23.142Z INFO  [lepton_jpeg::structs::lepton_file_writer] Number of threads: 8
2024-11-28T16:35:24.298Z INFO  [lepton_jpeg::structs::lepton_file_writer] worker threads 7843ms of CPU time in 1155ms of wall time
2024-11-28T16:35:24.298Z INFO  [lepton_jpeg::structs::lepton_file_writer] decompressing to verify contents
2024-11-28T16:35:25.898Z INFO  [lepton_jpeg_util] compressed input 22171278, output 17324074 bytes (compression = 28.0%)
2024-11-28T16:35:25.898Z INFO  [lepton_jpeg_util] Main thread CPU: 3075ms, Worker thread CPU: 18921 ms, walltime: 3075 ms

 Performance counter stats for 'taskset -c 10 nice -n -20 target/release/lepton_jpeg_util images/img_52MP_7k.jpg images/img_52MP_7k2.lep':

       851 285 476      cache-references                                                        (41,74%)
        75 269 619      cache-misses                     #    8,84% of all cache refs           (41,80%)
    14 046 950 734      cycles                                                                  (41,84%)
       834 209 080      ic_fetch_stall.ic_stall_back_pressure                                        (41,92%)
       955 883 963      stalled-cycles-frontend          #    6,80% frontend cycles idle        (42,06%)
    35 803 496 077      instructions                     #    2,55  insn per cycle            
                                                  #    0,03  stalled cycles per insn     (42,14%)
     3 708 243 777      branch-instructions                                                     (41,93%)
       129 017 906      branch-misses                    #    3,48% of all branches             (41,85%)
     5 080 950 553      ic_fetch_stall.ic_stall_any                                             (41,91%)
        46 981 068      ic_fetch_stall.ic_stall_dq_empty                                        (41,79%)
        63 463 302      l2_cache_misses_from_ic_miss                                            (41,77%)
     1 910 274 264      l2_latency.l2_cycles_waiting_on_fills                                        (41,80%)
           188 844      faults                                                                
                 1      migrations                                                            

       3,109446156 seconds time elapsed

       2,776699000 seconds user
       0,328609000 seconds sys
```