### PR TITLE
standardize on u32 vs i32 for jpeg coordinates/width etc to support large JPEGs

### DIFF
--- a/src/enabled_features.rs
+++ b/src/enabled_features.rs
@@ -8,10 +8,10 @@ pub struct EnabledFeatures {
     pub reject_dqts_with_zeros: bool,
 
     /// maximum jpeg width
-    pub max_jpeg_width: i32,
+    pub max_jpeg_width: u32,
 
     // maximum jpeg height
-    pub max_jpeg_height: i32,
+    pub max_jpeg_height: u32,
 
     /// Sadly C++ version has a bug where it uses 16 bit math in the SIMD path and 32 bit math in the scalar path
     pub use_16bit_dc_estimate: bool,
@@ -53,8 +53,8 @@ impl EnabledFeatures {
         Self {
             progressive: true,
             reject_dqts_with_zeros: false,
-            max_jpeg_height: i32::MAX,
-            max_jpeg_width: i32::MAX,
+            max_jpeg_height: u32::MAX,
+            max_jpeg_width: u32::MAX,
             use_16bit_dc_estimate: false,
             use_16bit_adv_predict: false,
             accept_invalid_dht: true,
@@ -70,8 +70,8 @@ impl EnabledFeatures {
         Self {
             progressive: true,
             reject_dqts_with_zeros: false,
-            max_jpeg_height: i32::MAX,
-            max_jpeg_width: i32::MAX,
+            max_jpeg_height: u32::MAX,
+            max_jpeg_width: u32::MAX,
             use_16bit_dc_estimate: true,
             use_16bit_adv_predict: true,
             accept_invalid_dht: true,

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,14 +113,14 @@ Options:
     override_if(
         &mut pargs,
         "--max-width",
-        parse_i32,
+        parse_u32,
         &mut enabled_features.max_jpeg_width,
     )?;
 
     override_if(
         &mut pargs,
         "--max-height",
-        parse_i32,
+        parse_u32,
         &mut enabled_features.max_jpeg_height,
     )?;
 

--- a/src/structs/bit_reader.rs
+++ b/src/structs/bit_reader.rs
@@ -23,10 +23,10 @@ pub struct BitReader<R> {
 }
 
 impl<R: BufRead + Seek> BitReader<R> {
-    pub fn get_stream_position(&mut self) -> i32 {
+    pub fn get_stream_position(&mut self) -> u32 {
         self.undo_read_ahead();
 
-        let pos: i32 = (self.inner.stream_position().unwrap() - self.start_offset)
+        let pos: u32 = (self.inner.stream_position().unwrap() - self.start_offset)
             .try_into()
             .unwrap();
 

--- a/src/structs/bit_reader.rs
+++ b/src/structs/bit_reader.rs
@@ -299,7 +299,7 @@ use std::io::Cursor;
 // test reading a simple bit pattern with an escaped 0xff inside it.
 #[test]
 fn read_simple() {
-    let arr = [0x12 as u8, 0x34, 0x45, 0x67, 0x89, 0xff, 00, 0xee];
+    let arr = [0x12u8, 0x34, 0x45, 0x67, 0x89, 0xff, 00, 0xee];
 
     let mut b = BitReader::new(Cursor::new(&arr));
 
@@ -338,7 +338,7 @@ fn read_simple() {
 // what happens when a file has 0xff as the last character (assume that it is an escaped 0xff)
 #[test]
 fn read_truncate_ff() {
-    let arr = [0x12 as u8, 0xff];
+    let arr = [0x12u8, 0xff];
 
     let mut b = BitReader::new(Cursor::new(&arr));
 

--- a/src/structs/bit_writer.rs
+++ b/src/structs/bit_writer.rs
@@ -151,7 +151,7 @@ use crate::structs::bit_reader::BitReader;
 // write a test pattern with an escape and see if it matches
 #[test]
 fn write_simple() {
-    let arr = [0x12 as u8, 0x34, 0x45, 0x67, 0x89, 0xff, 00, 0xee];
+    let arr = [0x12, 0x34, 0x45, 0x67, 0x89, 0xff, 00, 0xee];
 
     let mut b = BitWriter::new(1024);
 
@@ -178,7 +178,7 @@ fn roundtrip_bits() {
     {
         let mut b = BitWriter::new(1024);
         for i in 1..2048 {
-            b.write(i, u32_bit_length(i as u32) as u32);
+            b.write(i, u32_bit_length(i) as u32);
         }
 
         b.pad(0xff);

--- a/src/structs/block_based_image.rs
+++ b/src/structs/block_based_image.rs
@@ -16,11 +16,11 @@ use crate::structs::jpeg_header::JPegHeader;
 /// the image may only hold a subset of the components (specified by dpos_offset),
 /// but they can be merged
 pub struct BlockBasedImage {
-    block_width: i32,
+    block_width: u32,
 
-    original_height: i32,
+    original_height: u32,
 
-    dpos_offset: i32,
+    dpos_offset: u32,
 
     image: Vec<AlignedBlock>,
 }
@@ -32,22 +32,22 @@ impl BlockBasedImage {
     pub fn new(
         jpeg_header: &JPegHeader,
         component: usize,
-        luma_y_start: i32,
-        luma_y_end: i32,
+        luma_y_start: u32,
+        luma_y_end: u32,
     ) -> Self {
         let block_width = jpeg_header.cmp_info[component].bch;
         let original_height = jpeg_header.cmp_info[component].bcv;
         let max_size = block_width * original_height;
 
         let image_capcity = usize::try_from(
-            (i64::from(max_size) * i64::from(luma_y_end - luma_y_start)
-                + i64::from(jpeg_header.cmp_info[0].bcv - 1 /* round up */))
-                / i64::from(jpeg_header.cmp_info[0].bcv),
+            (u64::from(max_size) * u64::from(luma_y_end - luma_y_start)
+                + u64::from(jpeg_header.cmp_info[0].bcv - 1 /* round up */))
+                / u64::from(jpeg_header.cmp_info[0].bcv),
         )
         .unwrap();
 
-        let dpos_offset = i32::try_from(
-            i64::from(max_size) * i64::from(luma_y_start) / i64::from(jpeg_header.cmp_info[0].bcv),
+        let dpos_offset = u32::try_from(
+            u64::from(max_size) * u64::from(luma_y_start) / u64::from(jpeg_header.cmp_info[0].bcv),
         )
         .unwrap();
 
@@ -70,7 +70,7 @@ impl BlockBasedImage {
 
         for v in images {
             assert!(
-                v[index].dpos_offset == contents.len() as i32,
+                v[index].dpos_offset == contents.len() as u32,
                 "previous content should match new content"
             );
 
@@ -111,20 +111,20 @@ impl BlockBasedImage {
     }
 
     // blocks above the first line are never dereferenced
-    pub fn off_y(&self, y: i32) -> BlockContext {
+    pub fn off_y(&self, y: u32) -> BlockContext {
         return BlockContext::new(
             self.block_width * y,
-            self.block_width * (y - 1),
+            if y > 0 { self.block_width * (y - 1) } else { 0 },
             if (y & 1) != 0 { self.block_width } else { 0 },
             if (y & 1) != 0 { 0 } else { self.block_width },
         );
     }
 
-    pub fn get_block_width(&self) -> i32 {
+    pub fn get_block_width(&self) -> u32 {
         self.block_width
     }
 
-    pub fn get_original_height(&self) -> i32 {
+    pub fn get_original_height(&self) -> u32 {
         self.original_height
     }
 
@@ -133,7 +133,7 @@ impl BlockBasedImage {
     #[inline(always)]
     pub fn fill_up_to_dpos(
         &mut self,
-        dpos: i32,
+        dpos: u32,
         block_to_write: Option<AlignedBlock>,
     ) -> &mut AlignedBlock {
         // ensure that dpos_offset got set to the right value when we start writing
@@ -169,11 +169,11 @@ impl BlockBasedImage {
         return &mut self.image[relative_offset as usize];
     }
 
-    pub fn set_block_data(&mut self, dpos: i32, block_data: AlignedBlock) {
+    pub fn set_block_data(&mut self, dpos: u32, block_data: AlignedBlock) {
         self.fill_up_to_dpos(dpos, Some(block_data));
     }
 
-    pub fn get_block(&self, dpos: i32) -> &AlignedBlock {
+    pub fn get_block(&self, dpos: u32) -> &AlignedBlock {
         if (dpos - self.dpos_offset) as usize >= self.image.len() {
             return &EMPTY;
         } else {
@@ -191,7 +191,7 @@ impl BlockBasedImage {
     }
 
     #[inline(always)]
-    pub fn get_block_mut(&mut self, dpos: i32) -> &mut AlignedBlock {
+    pub fn get_block_mut(&mut self, dpos: u32) -> &mut AlignedBlock {
         self.fill_up_to_dpos(dpos, None)
     }
 }

--- a/src/structs/block_based_image.rs
+++ b/src/structs/block_based_image.rs
@@ -149,7 +149,7 @@ impl BlockBasedImage {
         if relative_offset < self.image.len() {
             // rewrite already written block
             if let Some(b) = block_to_write {
-                self.image[relative_offset as usize] = b;
+                self.image[relative_offset] = b;
             }
         } else {
             // need to extend the image length and add any necessary
@@ -166,7 +166,7 @@ impl BlockBasedImage {
             self.image.push(block_to_write.unwrap_or_default());
         }
 
-        return &mut self.image[relative_offset as usize];
+        return &mut self.image[relative_offset];
     }
 
     pub fn set_block_data(&mut self, dpos: u32, block_data: AlignedBlock) {

--- a/src/structs/block_context.rs
+++ b/src/structs/block_context.rs
@@ -8,11 +8,11 @@ use crate::structs::block_based_image::{AlignedBlock, BlockBasedImage, EMPTY_BLO
 use crate::structs::neighbor_summary::{NeighborSummary, NEIGHBOR_DATA_EMPTY};
 use crate::structs::probability_tables::ProbabilityTables;
 pub struct BlockContext {
-    cur_block_index: i32,
-    above_block_index: i32,
+    cur_block_index: u32,
+    above_block_index: u32,
 
-    cur_neighbor_summary_index: i32,
-    above_neighbor_summary_index: i32,
+    cur_neighbor_summary_index: u32,
+    above_neighbor_summary_index: u32,
 }
 pub struct NeighborData<'a> {
     pub above: &'a AlignedBlock,
@@ -25,13 +25,13 @@ pub struct NeighborData<'a> {
 impl BlockContext {
     // for debugging
     #[allow(dead_code)]
-    pub fn get_here_index(&self) -> i32 {
+    pub fn get_here_index(&self) -> u32 {
         self.cur_block_index
     }
 
     // as each new line BlockContext is set by `off_y`, no edge cases with dereferencing
     // out of bounds indices is possilbe, therefore no special treatment is needed
-    pub fn next(&mut self) -> i32 {
+    pub fn next(&mut self) -> u32 {
         self.cur_block_index += 1;
         self.above_block_index += 1;
         self.cur_neighbor_summary_index += 1;
@@ -41,10 +41,10 @@ impl BlockContext {
     }
 
     pub fn new(
-        cur_block_index: i32,
-        above_block_index: i32,
-        cur_neighbor_summary_index: i32,
-        above_neighbor_summary_index: i32,
+        cur_block_index: u32,
+        above_block_index: u32,
+        cur_neighbor_summary_index: u32,
+        above_neighbor_summary_index: u32,
     ) -> Self {
         return BlockContext {
             cur_block_index,

--- a/src/structs/branch.rs
+++ b/src/structs/branch.rs
@@ -231,7 +231,7 @@ fn test_all_probabilities() {
             continue;
         }
 
-        let mut new_f = Branch { counts: i as u16 };
+        let mut new_f = Branch { counts: i };
 
         for _k in 0..10 {
             old_f.record_obs_and_update(false);

--- a/src/structs/component_info.rs
+++ b/src/structs/component_info.rs
@@ -16,34 +16,34 @@ pub struct ComponentInfo {
     pub huff_ac: u8,
 
     /// sample factor vertical
-    pub sfv: i32,
+    pub sfv: u32,
 
     /// sample factor horizontal
-    pub sfh: i32,
+    pub sfh: u32,
 
     /// blocks in mcu
-    pub mbs: i32,
+    pub mbs: u32,
 
     /// block count vertical (interleaved)
-    pub bcv: i32,
+    pub bcv: u32,
 
     /// block count horizontal (interleaved)
-    pub bch: i32,
+    pub bch: u32,
 
     /// block count (all) (interleaved)
-    pub bc: i32,
+    pub bc: u32,
 
     /// block count vertical (non interleaved)
-    pub ncv: i32,
+    pub ncv: u32,
 
     /// block count horizontal (non interleaved)
-    pub nch: i32,
+    pub nch: u32,
 
     /// block count (all) (non interleaved)
-    pub nc: i32,
+    pub nc: u32,
 
     /// statistical identity
-    pub sid: i32,
+    pub sid: u32,
 
     /// jpeg internal id
     pub jid: u8,
@@ -53,16 +53,16 @@ impl Default for ComponentInfo {
     fn default() -> ComponentInfo {
         return ComponentInfo {
             q_table_index: 0xff,
-            sfv: -1,
-            sfh: -1,
-            mbs: -1,
-            bcv: -1,
-            bch: -1,
-            bc: -1,
-            ncv: -1,
-            nch: -1,
-            nc: -1,
-            sid: -1,
+            sfv: u32::MAX,
+            sfh: u32::MAX,
+            mbs: u32::MAX,
+            bcv: u32::MAX,
+            bch: u32::MAX,
+            bc: u32::MAX,
+            ncv: u32::MAX,
+            nch: u32::MAX,
+            nc: u32::MAX,
+            sid: u32::MAX,
             jid: 0xff,
             huff_dc: 0xff,
             huff_ac: 0xff,

--- a/src/structs/jpeg_read.rs
+++ b/src/structs/jpeg_read.rs
@@ -616,7 +616,7 @@ fn decode_ac_prg_fs<R: BufRead>(
         } else {
             // decode eobrun
             let s = l;
-            let n = bit_reader.read(u32::from(s))? as u16;
+            let n = bit_reader.read(u32::from(s))?;
             state.eobrun = decode_eobrun_bits(s, n);
 
             state.eobrun -= 1; // decrement eobrun ( for this one )
@@ -694,7 +694,7 @@ fn decode_ac_prg_sa<R: BufRead>(
             // decode eobrun
             eob = bpos;
             let s = l;
-            let n = bit_reader.read(u32::from(s))? as u16;
+            let n = bit_reader.read(u32::from(s))?;
             state.eobrun = decode_eobrun_bits(s, n);
 
             // since we hit EOB, the rest can be done with the zero block decoder

--- a/src/structs/jpeg_write.rs
+++ b/src/structs/jpeg_write.rs
@@ -51,8 +51,8 @@ pub fn jpeg_write_baseline_row_range(
     encoded_length: usize,
     overhang_byte: u8,
     num_overhang_bits: u8,
-    luma_y_start: i32,
-    luma_y_end: i32,
+    luma_y_start: u32,
+    luma_y_end: u32,
     mut last_dc: [i16; 4],
     image_data: &[BlockBasedImage],
     jenc: &JPegEncodingInfo,
@@ -92,7 +92,7 @@ pub fn jpeg_write_baseline_row_range(
         if cur_row.last_row_to_complete_mcu {
             recode_one_mcu_row(
                 &mut huffw,
-                cur_row.mcu_row_index * jenc.jpeg_header.mcuh,
+                cur_row.mcu_row_index * jenc.jpeg_header.mcuh.get(),
                 &mut last_dc,
                 image_data,
                 jenc,
@@ -138,7 +138,7 @@ pub fn jpeg_write_entire_scan(
         if cur_row.last_row_to_complete_mcu {
             let r = recode_one_mcu_row(
                 &mut huffw,
-                cur_row.mcu_row_index * jenc.jpeg_header.mcuh,
+                cur_row.mcu_row_index * jenc.jpeg_header.mcuh.get(),
                 &mut last_dc,
                 image_data,
                 jenc,
@@ -157,7 +157,7 @@ pub fn jpeg_write_entire_scan(
 #[inline(never)]
 fn recode_one_mcu_row(
     huffw: &mut BitWriter,
-    mcu: i32,
+    mcu: u32,
     lastdc: &mut [i16],
     framebuffer: &[BlockBasedImage],
     jenc: &JPegEncodingInfo,

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -35,8 +35,8 @@ pub fn lepton_decode_row_range<R: Read>(
     trunc: &TruncateComponents,
     image_data: &mut [BlockBasedImage],
     reader: &mut R,
-    min_y: i32,
-    max_y: i32,
+    min_y: u32,
+    max_y: u32,
     is_last_thread: bool,
     full_file_compression: bool,
     features: &EnabledFeatures,
@@ -131,8 +131,8 @@ fn decode_row_wrapper<R: Read>(
     image_data: &mut BlockBasedImage,
     qt: &QuantizationTables,
     neighbor_summary_cache: &mut [NeighborSummary],
-    curr_y: i32,
-    component_size_in_blocks: i32,
+    curr_y: u32,
+    component_size_in_blocks: u32,
     features: &EnabledFeatures,
 ) -> Result<()> {
     let mut block_context = image_data.off_y(curr_y);

--- a/src/structs/lepton_decoder.rs
+++ b/src/structs/lepton_decoder.rs
@@ -458,7 +458,7 @@ fn decode_one_edge<R: Read, const ALL_PRESENT: bool, const HORIZONTAL: bool>(
         if coef != 0 {
             num_non_zeros_edge -= 1;
             here_mut.set_coefficient(coord_tr, coef);
-            raster[coord_tr as usize] =
+            raster[coord_tr] =
                 i32::from(coef) * i32::from(qt.get_quantization_table_transposed()[coord_tr]);
         }
 

--- a/src/structs/lepton_encoder.rs
+++ b/src/structs/lepton_encoder.rs
@@ -34,8 +34,8 @@ pub fn lepton_encode_row_range<W: Write>(
     writer: &mut W,
     _thread_id: i32,
     colldata: &TruncateComponents,
-    min_y: i32,
-    max_y: i32,
+    min_y: u32,
+    max_y: u32,
     is_last_thread: bool,
     full_file_compression: bool,
     features: &EnabledFeatures,
@@ -155,8 +155,8 @@ fn process_row<W: Write>(
     image_data: &BlockBasedImage,
     qt: &QuantizationTables,
     neighbor_summary_cache: &mut [NeighborSummary],
-    curr_y: i32,
-    component_size_in_block: i32,
+    curr_y: u32,
+    component_size_in_block: u32,
     features: &EnabledFeatures,
 ) -> Result<()> {
     let mut block_context = image_data.off_y(curr_y);

--- a/src/structs/lepton_file_reader.rs
+++ b/src/structs/lepton_file_reader.rs
@@ -329,7 +329,7 @@ impl LeptonFileReader {
             let mut markers = Vec::new();
 
             let cumulative_reset_markers = if lh.jpeg_header.rsti != 0 {
-                ((lh.jpeg_header.mcuh * lh.jpeg_header.mcuv) - 1) / lh.jpeg_header.rsti
+                (lh.jpeg_header.mcuc - 1) / lh.jpeg_header.rsti
             } else {
                 0
             } as u8;

--- a/src/structs/lepton_file_reader.rs
+++ b/src/structs/lepton_file_reader.rs
@@ -334,8 +334,8 @@ impl LeptonFileReader {
                 0
             } as u8;
 
-            for i in 0..lh.rst_err[0] as u8 {
-                let rst = (jpeg_code::RST0 + ((cumulative_reset_markers + i) & 7)) as u8;
+            for i in 0..lh.rst_err[0] {
+                let rst = jpeg_code::RST0 + ((cumulative_reset_markers + i) & 7);
                 markers.push(0xFF);
                 markers.push(rst);
             }

--- a/src/structs/lepton_file_writer.rs
+++ b/src/structs/lepton_file_writer.rs
@@ -380,7 +380,7 @@ fn split_row_handoffs_to_threads(
 
     info!("Number of threads: {0}", num_threads);
 
-    let mut selected_splits = Vec::with_capacity(num_threads as usize);
+    let mut selected_splits = Vec::with_capacity(num_threads);
 
     if num_threads == 1 {
         // Single thread execution - no split, run on the whole range

--- a/src/structs/lepton_header.rs
+++ b/src/structs/lepton_header.rs
@@ -205,8 +205,6 @@ impl LeptonHeader {
 
             let last = &mut self.thread_handoff[num_threads - 1];
 
-            let max_last_segment_size = max_last_segment_size;
-
             if last.segment_size > max_last_segment_size {
                 // re-adjust the last segment size
                 last.segment_size = max_last_segment_size;

--- a/src/structs/lepton_header.rs
+++ b/src/structs/lepton_header.rs
@@ -262,7 +262,7 @@ impl LeptonHeader {
         // beginning here: recovery information (needed for exact JPEG recovery)
         // read further recovery information if any
         loop {
-            let mut current_lepton_marker = [0 as u8; 3];
+            let mut current_lepton_marker = [0u8; 3];
             match header_reader.read_exact(&mut current_lepton_marker) {
                 Ok(_) => {}
                 Err(e) => {
@@ -468,7 +468,7 @@ impl LeptonHeader {
             mrw.write_u32::<LittleEndian>(self.rst_cnt.len() as u32)?;
 
             for i in 0..self.rst_cnt.len() {
-                mrw.write_u32::<LittleEndian>(self.rst_cnt[i] as u32)?;
+                mrw.write_u32::<LittleEndian>(self.rst_cnt[i])?;
             }
         }
 

--- a/src/structs/mod.rs
+++ b/src/structs/mod.rs
@@ -7,6 +7,7 @@
 // Don't allow any unsafe code by default. Since this code has to potentially deal with
 // badly/maliciously formatted images, we want this extra level of safety.
 #![forbid(unsafe_code)]
+#![forbid(trivial_numeric_casts)]
 
 mod bit_reader;
 mod bit_writer;

--- a/src/structs/quantization_tables.rs
+++ b/src/structs/quantization_tables.rs
@@ -51,7 +51,7 @@ impl QuantizationTables {
                     freq_max /= retval.quantization_table[coord];
                 }
 
-                let max_len = u16_bit_length(freq_max) as u8;
+                let max_len = u16_bit_length(freq_max);
                 if max_len > RESIDUAL_NOISE_FLOOR as u8 {
                     retval.min_noise_threshold[i] = max_len - RESIDUAL_NOISE_FLOOR as u8;
                 }

--- a/src/structs/row_spec.rs
+++ b/src/structs/row_spec.rs
@@ -8,12 +8,12 @@ use crate::consts::COLOR_CHANNEL_NUM_BLOCK_TYPES;
 use crate::structs::block_based_image::BlockBasedImage;
 
 pub struct RowSpec {
-    pub min_row_luma_y: i32,
-    pub next_row_luma_y: i32,
-    pub luma_y: i32,
+    pub min_row_luma_y: u32,
+    pub next_row_luma_y: u32,
+    pub luma_y: u32,
     pub component: usize,
-    pub curr_y: i32,
-    pub mcu_row_index: i32,
+    pub curr_y: u32,
+    pub mcu_row_index: u32,
     pub last_row_to_complete_mcu: bool,
     pub skip: bool,
     pub done: bool,
@@ -23,7 +23,7 @@ impl RowSpec {
     pub fn get_row_spec_from_index(
         decode_index: u32,
         image_data: &[BlockBasedImage],
-        mcuv: i32, // number of mcus
+        mcuv: u32, // number of mcus
         max_coded_heights: &[u32],
     ) -> RowSpec {
         assert!(
@@ -44,14 +44,14 @@ impl RowSpec {
         }
 
         let mcu_row = decode_index / mcu_multiple;
-        let min_row_luma_y = (mcu_row * component_multiple[0]) as i32;
+        let min_row_luma_y = mcu_row * component_multiple[0];
         let mut retval = RowSpec {
             skip: false,
             done: false,
-            mcu_row_index: mcu_row as i32,
+            mcu_row_index: mcu_row,
             component: num_cmp,
             min_row_luma_y,
-            next_row_luma_y: min_row_luma_y + component_multiple[0] as i32,
+            next_row_luma_y: min_row_luma_y + component_multiple[0],
             luma_y: min_row_luma_y,
             curr_y: 0,
             last_row_to_complete_mcu: false,
@@ -63,11 +63,11 @@ impl RowSpec {
         loop {
             if place_within_scan < component_multiple[i] {
                 retval.component = i;
-                retval.curr_y = ((mcu_row * component_multiple[i]) + place_within_scan) as i32;
+                retval.curr_y = (mcu_row * component_multiple[i]) + place_within_scan;
                 retval.last_row_to_complete_mcu =
                     (place_within_scan + 1 == component_multiple[i]) && (i == 0);
 
-                if retval.curr_y >= max_coded_heights[i] as i32 {
+                if retval.curr_y >= max_coded_heights[i] {
                     retval.skip = true;
                     retval.done = true; // assume true, but if we find something that needs coding, set false
                     for j in 0..num_cmp - 1 {

--- a/src/structs/row_spec.rs
+++ b/src/structs/row_spec.rs
@@ -38,8 +38,8 @@ impl RowSpec {
         let mut mcu_multiple = 0;
 
         for i in 0..num_cmp {
-            heights.push(image_data[i].get_original_height() as u32);
-            component_multiple.push(heights[i] / mcuv as u32);
+            heights.push(image_data[i].get_original_height());
+            component_multiple.push(heights[i] / mcuv);
             mcu_multiple += component_multiple[i];
         }
 

--- a/src/structs/simple_hash.rs
+++ b/src/structs/simple_hash.rs
@@ -31,7 +31,7 @@ impl SimpleHashProvider for u32 {
 
 impl SimpleHashProvider for u64 {
     fn get_u64(&self) -> u64 {
-        return *self as u64;
+        return *self;
     }
 }
 
@@ -41,7 +41,7 @@ impl SimpleHash {
     }
 
     pub fn hash<T: SimpleHashProvider>(&mut self, v: T) {
-        self.hash = (Wrapping(self.hash as u64) * Wrapping(13u64) + Wrapping(v.get_u64())).0;
+        self.hash = (Wrapping(self.hash) * Wrapping(13u64) + Wrapping(v.get_u64())).0;
     }
 
     pub fn get(&self) -> u32 {

--- a/src/structs/thread_handoff.rs
+++ b/src/structs/thread_handoff.rs
@@ -12,10 +12,10 @@ use crate::consts::COLOR_CHANNEL_NUM_BLOCK_TYPES;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct ThreadHandoff {
-    pub luma_y_start: i32,
-    pub luma_y_end: i32,
-    pub segment_offset_in_file: i32,
-    pub segment_size: i32,
+    pub luma_y_start: u32,
+    pub luma_y_end: u32,
+    pub segment_offset_in_file: u32,
+    pub segment_size: u32,
     pub overhang_byte: u8,
     pub num_overhang_bits: u8,
     pub last_dc: [i16; 4],
@@ -27,10 +27,10 @@ impl ThreadHandoff {
 
         for _i in 0..num_threads {
             let mut th = ThreadHandoff {
-                luma_y_start: data.read_u16::<LittleEndian>()? as i32,
+                luma_y_start: data.read_u16::<LittleEndian>()? as u32,
                 luma_y_end: 0,             // filled in later
                 segment_offset_in_file: 0, // not serialized
-                segment_size: data.read_i32::<LittleEndian>()?,
+                segment_size: data.read_u32::<LittleEndian>()?,
                 overhang_byte: data.read_u8()?,
                 num_overhang_bits: data.read_u8()?,
                 last_dc: [0; 4],
@@ -92,7 +92,7 @@ impl ThreadHandoff {
             overhang_byte: from.overhang_byte,
             num_overhang_bits: from.num_overhang_bits,
             luma_y_end: to.luma_y_end,
-            segment_size: ThreadHandoff::get_combine_thread_range_segment_size(from, to) as i32,
+            segment_size: ThreadHandoff::get_combine_thread_range_segment_size(from, to) as u32,
             last_dc: from.last_dc,
         };
 

--- a/src/structs/truncate_components.rs
+++ b/src/structs/truncate_components.rs
@@ -11,9 +11,9 @@ use crate::structs::jpeg_header::JPegHeader;
 
 #[derive(Debug, Clone)]
 struct TrucateComponentsInfo {
-    trunc_bcv: i32, // the number of vertical components in this (truncated) image
+    trunc_bcv: u32, // the number of vertical components in this (truncated) image
 
-    trunc_bc: i32,
+    trunc_bc: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -22,9 +22,9 @@ pub struct TruncateComponents {
 
     pub components_count: usize,
 
-    pub mcu_count_horizontal: i32,
+    pub mcu_count_horizontal: u32,
 
-    pub mcu_count_vertical: i32,
+    pub mcu_count_vertical: u32,
 }
 
 impl Default for TruncateComponents {
@@ -40,8 +40,8 @@ impl Default for TruncateComponents {
 
 impl TruncateComponents {
     pub fn init(&mut self, jpeg_header: &JPegHeader) {
-        self.mcu_count_horizontal = jpeg_header.mcuh;
-        self.mcu_count_vertical = jpeg_header.mcuv;
+        self.mcu_count_horizontal = jpeg_header.mcuh.get();
+        self.mcu_count_vertical = jpeg_header.mcuv.get();
         self.components_count = jpeg_header.cmpc;
 
         for i in 0..jpeg_header.cmpc {
@@ -61,7 +61,7 @@ impl TruncateComponents {
         return retval;
     }
 
-    pub fn set_truncation_bounds(&mut self, jpeg_header: &JPegHeader, max_d_pos: [i32; 4]) {
+    pub fn set_truncation_bounds(&mut self, jpeg_header: &JPegHeader, max_d_pos: [u32; 4]) {
         for i in 0..self.components_count {
             TruncateComponents::set_block_count_d_pos(
                 &mut self.trunc_info[i],
@@ -72,15 +72,15 @@ impl TruncateComponents {
         }
     }
 
-    pub fn get_block_height(&self, cmp: usize) -> i32 {
+    pub fn get_block_height(&self, cmp: usize) -> u32 {
         return self.trunc_info[cmp].trunc_bcv;
     }
 
     fn set_block_count_d_pos(
         ti: &mut TrucateComponentsInfo,
         ci: &ComponentInfo,
-        trunc_bc: i32,
-        mcu_count_vertical: i32,
+        trunc_bc: u32,
+        mcu_count_vertical: u32,
     ) {
         assert!(
             ci.bcv == (ci.bc / ci.bch) + (if ci.bc % ci.bch != 0 { 1 } else { 0 }),
@@ -105,12 +105,12 @@ impl TruncateComponents {
         ti.trunc_bc = trunc_bc;
     }
 
-    fn get_min_vertical_extcmp_multiple(cmp_info: &ComponentInfo, mcu_count_vertical: i32) -> i32 {
+    fn get_min_vertical_extcmp_multiple(cmp_info: &ComponentInfo, mcu_count_vertical: u32) -> u32 {
         let luma_height = cmp_info.bcv;
         return luma_height / mcu_count_vertical;
     }
 
-    pub fn get_component_sizes_in_blocks(&self) -> Vec<i32> {
+    pub fn get_component_sizes_in_blocks(&self) -> Vec<u32> {
         let mut retval = Vec::new();
         for i in 0..self.components_count {
             retval.push(self.trunc_info[i].trunc_bc);

--- a/src/structs/truncate_components.rs
+++ b/src/structs/truncate_components.rs
@@ -56,7 +56,7 @@ impl TruncateComponents {
         let mut retval = Vec::<u32>::new();
 
         for i in 0..self.components_count {
-            retval.push(self.trunc_info[i].trunc_bcv as u32);
+            retval.push(self.trunc_info[i].trunc_bcv);
         }
         return retval;
     }


### PR DESCRIPTION
We were using i32s which overflow for very large JPEGs which can be 65535x65535. 

In general this cleans up the code quite a bit. 