### PR TITLE
Devli

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -109,6 +109,25 @@ pub const fn devli(s: u8, value: u16) -> i16 {
     }
 }
 
+/// check to make sure the behavior hasn't changed even with the optimization
+#[test]
+fn devli_test() {
+    for s in 0u8..15 {
+        for value in 0..(1 << s) {
+            assert_eq!(
+                devli(s, value) as i16,
+                if s == 0 {
+                    value as i16
+                } else if value < (1 << (s as u16 - 1)) {
+                    value as i16 + (-1 << s as i16) + 1
+                } else {
+                    value as i16
+                }
+            );
+        }
+    }
+}
+
 #[inline(always)]
 pub const fn b_short(v1: u8, v2: u8) -> u16 {
     ((v1 as u16) << 8) + v2 as u16

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -102,29 +102,10 @@ pub fn has_ff(v: u64) -> bool {
 pub const fn devli(s: u8, value: u16) -> i16 {
     let shifted = 1 << s;
 
-    if value & (shifted >> 1) != 0 {
+    if value >= (shifted >> 1) {
         value as i16
     } else {
-        value.wrapping_add(2).wrapping_add(!shifted) as i16
-    }
-}
-
-/// check to make sure the behavior hasn't changed even with the optimization
-#[test]
-fn devli_test() {
-    for s in 0u8..15 {
-        for value in 0..(1 << s) {
-            assert_eq!(
-                devli(s, value) as i16,
-                if s == 0 {
-                    value as i16
-                } else if value < (1 << (s as u16 - 1)) {
-                    value as i16 + (-1 << s as i16) + 1
-                } else {
-                    value as i16
-                }
-            );
-        }
+        (value + !(shifted - 1) + 1) as i16
     }
 }
 

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -99,20 +99,20 @@ pub fn has_ff(v: u64) -> bool {
 }
 
 #[inline(always)]
-pub const fn devli(s: u8, value: u16) -> i16 {
-    let shifted = 1 << s;
+pub const fn devli(s: u32, value: u32) -> i16 {
+    let shifted = (1 << s) - 1;
 
-    if value >= (shifted >> 1) {
+    if (value << 1) > shifted {
         value as i16
     } else {
-        (value + !(shifted - 1) + 1) as i16
+        value.wrapping_sub(shifted) as i16
     }
 }
 
 /// check to make sure the behavior hasn't changed even with the optimization
 #[test]
 fn devli_test() {
-    for s in 0u8..15 {
+    for s in 0u32..15 {
         for value in 0..(1 << s) {
             assert_eq!(
                 devli(s, value) as i16,

--- a/src/jpeg/bit_reader.rs
+++ b/src/jpeg/bit_reader.rs
@@ -123,7 +123,7 @@ impl<R: BufRead> BitReader<R> {
                 while bytes_left >= 2 {
                     if v & 0xff == 0xff {
                         if v & 0xff00 != 0 {
-                            // escape sequence or reset marker, just exit the loop and let fill_register handle it
+                            // reset marker or end of scan, just exit the loop and let fill_register handle it
                             break;
                         }
 

--- a/src/jpeg/bit_reader.rs
+++ b/src/jpeg/bit_reader.rs
@@ -59,7 +59,7 @@ impl<R: BufRead + Seek> BitReader<R> {
 
 impl<R: BufRead> BitReader<R> {
     #[inline(always)]
-    pub fn read(&mut self, bits_to_read: u32) -> std::io::Result<u16> {
+    pub fn read(&mut self, bits_to_read: u32) -> std::io::Result<u32> {
         if bits_to_read == 0 {
             return Ok(0);
         }
@@ -69,7 +69,7 @@ impl<R: BufRead> BitReader<R> {
         }
 
         let retval =
-            (self.bits >> (self.bits_left - bits_to_read) & ((1 << bits_to_read) - 1)) as u16;
+            ((self.bits >> (self.bits_left - bits_to_read)) as u32) & ((1 << bits_to_read) - 1);
         self.bits_left -= bits_to_read;
         return Ok(retval);
     }
@@ -224,7 +224,7 @@ impl<R: BufRead> BitReader<R> {
                 }
                 Some(x) => {
                     // if we already saw a padding, then it should match
-                    let expected = u16::from(x) & all_one;
+                    let expected = u32::from(x) & all_one;
                     if actual != expected {
                         return err_exit_code(ExitCode::InvalidPadding, format!("padding of {0} bits should be set to 1 actual={1:b} expected={2:b}", num_bits_to_read, actual, expected).as_str());
                     }

--- a/src/jpeg/bit_writer.rs
+++ b/src/jpeg/bit_writer.rs
@@ -266,7 +266,7 @@ fn roundtrip_randombits() {
 
                     assert_eq!(
                         expected_peek_byte & mask,
-                        peekcode & mask,
+                        (peekcode as u8) & mask,
                         "peek unexpected result"
                     );
 

--- a/src/jpeg/bit_writer.rs
+++ b/src/jpeg/bit_writer.rs
@@ -271,7 +271,7 @@ fn roundtrip_randombits() {
                     );
 
                     assert_eq!(
-                        code,
+                        code as u32,
                         r.read(numbits as u32).unwrap(),
                         "read unexpected result"
                     );


### PR DESCRIPTION
Improve speed of JPEG reading
- Best devli ever (sorry @Melirius )
- Consistently use 32 bit math to avoid unnecessary widen/narrow conversions
- Optimistically fill 8 byte fill register so that branching generally only happens in one location
- Use LeptonError in BitReader to avoid unnecessary error conversions, since LeptonError is as small as std::io::Error now