### PR TITLE
Max threads for large files

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -74,17 +74,11 @@ pub const NON_ZERO_TO_BIN_7X7: [u8; 50] = [
     8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
 ];
 
-//pub const MAX_FILE_SIZE_BYTES : i32 = 128 * 1024 * 1024;
-pub const MAX_THREADS: usize = 8;
-
 pub const RESIDUAL_NOISE_FLOOR: usize = 7;
 
 pub const LEPTON_VERSION: u8 = 1; // Lepton version, same as used by Lepton C++ since we support the same format
 
-//pub const LogMaxNumerator : i32 = 18;
-//pub const DefaultEncodingThreads : usize = 8;
 pub const SMALL_FILE_BYTES_PER_ENCDOING_THREAD: usize = 125000;
-//pub const TailGarbageBufferLength : i32 = 1024;
 pub const MAX_THREADS_SUPPORTED_BY_LEPTON_FORMAT: usize = 16; // Number of threads minus 1 should fit in 4 bits
 
 //pub const SingleFFByte : [u8;1] = [ 0xFF ];

--- a/src/structs/lepton_file_writer.rs
+++ b/src/structs/lepton_file_writer.rs
@@ -216,7 +216,7 @@ fn run_lepton_encoder_threads<W: Write + Seek>(
     // Get number of threads. Verify that it is at most MAX_THREADS and fits in 4 bits for serialization.
     let num_threads = thread_handoffs.len();
     assert!(
-        num_threads <= MAX_THREADS && num_threads <= MAX_THREADS_SUPPORTED_BY_LEPTON_FORMAT,
+        num_threads <= MAX_THREADS_SUPPORTED_BY_LEPTON_FORMAT,
         "Too many thread handoffs"
     );
 
@@ -329,7 +329,7 @@ fn get_number_of_threads_for_encoding(
     framebuffer_byte_size: usize,
     max_threads_to_use: usize,
 ) -> usize {
-    let mut num_threads = cmp::min(max_threads_to_use, MAX_THREADS);
+    let mut num_threads = cmp::min(max_threads_to_use, MAX_THREADS_SUPPORTED_BY_LEPTON_FORMAT);
 
     if num_rows / 2 < num_threads {
         num_threads = cmp::max(num_rows / 2, 1);


### PR DESCRIPTION
This PR increases max number of threads to be used to 16 - limit allowable by Lepton file structure.