### PR TITLE
update to Rust 2024

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
 
 env:
@@ -10,30 +10,27 @@ env:
 
 jobs:
   build:
-
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        toolchain: stable
-        targets: wasm32-wasip1,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu
-        components: rustfmt,clippy
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: stable
+          targets: wasm32-wasip1,aarch64-unknown-linux-musl,x86_64-pc-windows-msvc,x86_64-unknown-linux-gnu
+          components: rustfmt,clippy
 
-    - name: Check formatting
-      run: cargo fmt --check --all
-    - name: Build default target
-      run: cargo build --locked --workspace
-    - name: Build wasm32-wasip1
-      run: cargo build --locked --target wasm32-wasip1 --manifest-path lib/Cargo.toml
-    - name: Build aarch64-unknown-linux-musl
-      run: cargo build --locked --target aarch64-unknown-linux-musl --manifest-path lib/Cargo.toml
-    - name: Build x86_64-pc-windows-msvc
-      run: cargo build --locked --target x86_64-pc-windows-msvc --lib --workspace
-    - name: Build x86_64-pc-windows-msvc release
-      run: cargo build --locked --target x86_64-pc-windows-msvc --lib --workspace --release
-    - name: Run tests
-      run: cargo test --locked --workspace
-
-      
+      - name: Check formatting
+        run: cargo fmt --check --all
+      - name: Build default target
+        run: cargo build --locked --workspace
+      - name: Build wasm32-wasip1
+        run: cargo build --locked --target wasm32-wasip1 --manifest-path lib/Cargo.toml
+      - name: Build aarch64-unknown-linux-musl
+        run: cargo build --locked --target aarch64-unknown-linux-musl --manifest-path lib/Cargo.toml
+      - name: Build x86_64-pc-windows-msvc
+        run: cargo build --locked --target x86_64-pc-windows-msvc --lib --workspace
+      - name: Build x86_64-pc-windows-msvc release
+        run: cargo build --locked --target x86_64-pc-windows-msvc --lib --workspace --release
+      - name: Run tests
+        run: cargo test --locked --workspace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,7 +314,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "lepton_jpeg"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "lepton_jpeg_dll"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "lepton_jpeg",
  "rayon",
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "lepton_jpeg_root"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "lepton_jpeg",
  "rand",
@@ -352,7 +352,7 @@ dependencies = [
 
 [[package]]
 name = "lepton_jpeg_util"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "lepton_jpeg",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "lepton_jpeg_root"
-version = "0.5.4"
-edition = "2021"
+version = "0.5.5"
+edition = "2024"
 authors = ["Kristof Roomp <kristofr@microsoft.com>"]
 
 [profile.release]
-debug=true
+debug = true
 
 [workspace]
-members = ["lib","dll","util"]
+members = ["lib", "dll", "util"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -20,6 +20,3 @@ rstest = "0.22"
 rand = "0.8"
 rand_chacha = "0.3"
 siphasher = "1"
-
-
-

--- a/dll/Cargo.toml
+++ b/dll/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lepton_jpeg_dll"
-version = "0.5.4"
-edition = "2021"
+version = "0.5.5"
+edition = "2024"
 authors = ["Kristof Roomp <kristofr@microsoft.com>"]
 
 [dependencies]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,7 +2,7 @@
 name = "lepton_jpeg-fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
+edition = "2024"
 
 [package.metadata]
 cargo-fuzz = true

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "lepton_jpeg"
-version = "0.5.4"
-edition = "2021"
+version = "0.5.5"
+edition = "2024"
 authors = ["Kristof Roomp <kristofr@microsoft.com>"]
 
-# requires scoped threads and IsTerminal
-rust-version = "1.85"
+# requires scoped threads, IsTerminal, let chains
+rust-version = "1.88"
 description = "Rust port of the Lepton JPEG compression library"
 readme = "../README.md"
 repository = "https://github.com/microsoft/lepton_jpeg_rust"

--- a/lib/src/helpers.rs
+++ b/lib/src/helpers.rs
@@ -4,7 +4,7 @@
  *  This software incorporates material from third parties. See NOTICE.txt for details.
  *--------------------------------------------------------------------------------------------*/
 
-use std::panic::{catch_unwind, AssertUnwindSafe};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use crate::lepton_error::{ExitCode, LeptonError};
 
@@ -118,11 +118,7 @@ pub fn calc_sign_index(val: i16) -> usize {
     if val == 0 {
         0
     } else {
-        if val > 0 {
-            1
-        } else {
-            2
-        }
+        if val > 0 { 1 } else { 2 }
     }
 }
 
@@ -136,8 +132,8 @@ pub fn needs_to_grow<T>(v: &Vec<T>, additional: usize) -> bool {
 
 #[cfg(test)]
 pub fn get_rand_from_seed(seed: [u8; 32]) -> rand_chacha::ChaCha12Rng {
-    use rand_chacha::rand_core::SeedableRng;
     use rand_chacha::ChaCha12Rng;
+    use rand_chacha::rand_core::SeedableRng;
 
     ChaCha12Rng::from_seed(seed)
 }

--- a/lib/src/jpeg/bit_reader.rs
+++ b/lib/src/jpeg/bit_reader.rs
@@ -8,7 +8,7 @@ use std::io::BufRead;
 
 use super::jpeg_code;
 use crate::helpers::has_ff;
-use crate::lepton_error::{err_exit_code, ExitCode};
+use crate::lepton_error::{ExitCode, err_exit_code};
 use crate::{LeptonError, StreamPosition};
 
 // Implemenation of bit reader on top of JPEG data stream as read by a reader

--- a/lib/src/jpeg/block_based_image.rs
+++ b/lib/src/jpeg/block_based_image.rs
@@ -6,7 +6,7 @@
 
 use bytemuck::{cast, cast_ref};
 use log::info;
-use wide::{i16x8, CmpEq};
+use wide::{CmpEq, i16x8};
 
 use crate::consts::ZIGZAG_TO_TRANSPOSED;
 

--- a/lib/src/jpeg/jpeg_header.rs
+++ b/lib/src/jpeg/jpeg_header.rs
@@ -36,11 +36,11 @@ use std::fmt::Debug;
 use std::io::{Cursor, Read, Write};
 use std::num::NonZeroU32;
 
+use crate::LeptonError;
 use crate::consts::JpegType;
 use crate::enabled_features::EnabledFeatures;
 use crate::helpers::*;
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode, Result};
-use crate::LeptonError;
+use crate::lepton_error::{AddContext, ExitCode, Result, err_exit_code};
 
 use super::component_info::ComponentInfo;
 use super::jpeg_code;

--- a/lib/src/jpeg/jpeg_position_state.rs
+++ b/lib/src/jpeg/jpeg_position_state.rs
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 use crate::consts::{JpegDecodeStatus, JpegType};
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode};
+use crate::lepton_error::{AddContext, ExitCode, err_exit_code};
 use crate::{LeptonError, Result};
 
 use super::jpeg_header::{HuffCodes, JpegHeader};

--- a/lib/src/jpeg/jpeg_read.rs
+++ b/lib/src/jpeg/jpeg_read.rs
@@ -36,14 +36,14 @@ use std::cmp::{self, max};
 use std::io::{BufRead, Read, Seek, SeekFrom};
 
 use crate::helpers::*;
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode, Result};
-use crate::{consts::*, EnabledFeatures};
+use crate::lepton_error::{AddContext, ExitCode, Result, err_exit_code};
+use crate::{EnabledFeatures, consts::*};
 
 use super::bit_reader::BitReader;
 use super::block_based_image::{AlignedBlock, BlockBasedImage};
 use super::jpeg_code;
 use super::jpeg_header::{
-    parse_jpeg_header, HuffTree, JpegHeader, ReconstructionInfo, RestartSegmentCodingInfo,
+    HuffTree, JpegHeader, ReconstructionInfo, RestartSegmentCodingInfo, parse_jpeg_header,
 };
 use super::jpeg_position_state::JpegPositionState;
 

--- a/lib/src/jpeg/jpeg_write.rs
+++ b/lib/src/jpeg/jpeg_write.rs
@@ -33,11 +33,11 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
 use bytemuck::{cast, cast_ref};
-use wide::{i16x16, CmpEq};
+use wide::{CmpEq, i16x16};
 
 use crate::consts::{JpegDecodeStatus, JpegType};
 use crate::helpers::u16_bit_length;
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode};
+use crate::lepton_error::{AddContext, ExitCode, err_exit_code};
 
 use crate::Result;
 
@@ -641,7 +641,7 @@ fn round_trip_block(block: &AlignedBlock, expected: &[u8]) {
     use std::io::Cursor;
 
     use super::bit_reader::BitReader;
-    use super::jpeg_header::{generate_huff_table_from_distribution, HuffTree};
+    use super::jpeg_header::{HuffTree, generate_huff_table_from_distribution};
     use super::jpeg_read::decode_block_seq;
 
     let mut bitwriter = BitWriter::new(1024);

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -50,7 +50,7 @@ pub use structs::lepton_file_writer::get_git_version;
 
 use crate::lepton_error::{AddContext, Result};
 pub use crate::structs::simple_threadpool::{
-    LeptonThreadPool, LeptonThreadPriority, SimpleThreadPool, DEFAULT_THREAD_POOL,
+    DEFAULT_THREAD_POOL, LeptonThreadPool, LeptonThreadPriority, SimpleThreadPool,
 };
 
 /// Trait for types that can provide the current position in a stream. This

--- a/lib/src/metrics.rs
+++ b/lib/src/metrics.rs
@@ -111,9 +111,10 @@ impl Metrics {
                 x.1.total_bits,
                 x.1.total_compressed,
                 x.1.total_compressed * 100 / x.1.total_bits,
-                (x.1.total_bits - x.1.total_compressed)/(8*1024),
+                (x.1.total_bits - x.1.total_compressed) / (8 * 1024),
                 (x.1.total_compressed as f64) * 100f64 / (total_compressed as f64),
-                ((x.1.total_bits - x.1.total_compressed) as f64)/(total_compressed as f64)*100f64
+                ((x.1.total_bits - x.1.total_compressed) as f64) / (total_compressed as f64)
+                    * 100f64
             );
         }
 

--- a/lib/src/structs/block_context.rs
+++ b/lib/src/structs/block_context.rs
@@ -5,7 +5,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 use crate::jpeg::block_based_image::{AlignedBlock, BlockBasedImage, EMPTY_BLOCK};
-use crate::structs::neighbor_summary::{NeighborSummary, NEIGHBOR_DATA_EMPTY};
+use crate::structs::neighbor_summary::{NEIGHBOR_DATA_EMPTY, NeighborSummary};
 use crate::structs::probability_tables::ProbabilityTables;
 pub struct BlockContext {
     block_width: u32,

--- a/lib/src/structs/idct.rs
+++ b/lib/src/structs/idct.rs
@@ -82,8 +82,16 @@ pub fn run_idct(block: &[i32x8; 8]) -> AlignedBlock {
     ];
 
     // transpose and now do vertical
-    let [mut yv0, mut yv1, mut yv2, mut yv3, mut yv4, mut yv5, mut yv6, mut yv7] =
-        i32x8::transpose(row);
+    let [
+        mut yv0,
+        mut yv1,
+        mut yv2,
+        mut yv3,
+        mut yv4,
+        mut yv5,
+        mut yv6,
+        mut yv7,
+    ] = i32x8::transpose(row);
 
     yv0 = (yv0 << 8) + 8192;
     yv4 = yv4 << 8;

--- a/lib/src/structs/lepton_decoder.rs
+++ b/lib/src/structs/lepton_decoder.rs
@@ -11,13 +11,14 @@ use bytemuck::cast_mut;
 use default_boxed::DefaultBoxed;
 use wide::i32x8;
 
+use crate::Result;
 use crate::consts::UNZIGZAG_49_TR;
 use crate::enabled_features::EnabledFeatures;
 use crate::helpers::u16_bit_length;
 use crate::jpeg::block_based_image::{AlignedBlock, BlockBasedImage};
 use crate::jpeg::row_spec::RowSpec;
 use crate::jpeg::truncate_components::*;
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode};
+use crate::lepton_error::{AddContext, ExitCode, err_exit_code};
 use crate::metrics::Metrics;
 use crate::structs::block_context::{BlockContext, NeighborData};
 use crate::structs::model::{Model, ModelPerColor};
@@ -25,7 +26,6 @@ use crate::structs::neighbor_summary::NeighborSummary;
 use crate::structs::probability_tables::ProbabilityTables;
 use crate::structs::quantization_tables::QuantizationTables;
 use crate::structs::vpx_bool_reader::VPXBoolReader;
-use crate::Result;
 
 // reads stream from reader and populates image_data with the decoded data
 

--- a/lib/src/structs/lepton_encoder.rs
+++ b/lib/src/structs/lepton_encoder.rs
@@ -11,13 +11,14 @@ use bytemuck::cast;
 use default_boxed::DefaultBoxed;
 use wide::i32x8;
 
+use crate::Result;
 use crate::consts::UNZIGZAG_49_TR;
 use crate::enabled_features::EnabledFeatures;
 use crate::helpers::*;
 use crate::jpeg::block_based_image::{AlignedBlock, BlockBasedImage};
 use crate::jpeg::row_spec::RowSpec;
 use crate::jpeg::truncate_components::*;
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode};
+use crate::lepton_error::{AddContext, ExitCode, err_exit_code};
 use crate::metrics::Metrics;
 use crate::structs::block_context::{BlockContext, NeighborData};
 use crate::structs::model::{Model, ModelPerColor};
@@ -25,7 +26,6 @@ use crate::structs::neighbor_summary::NeighborSummary;
 use crate::structs::probability_tables::ProbabilityTables;
 use crate::structs::quantization_tables::QuantizationTables;
 use crate::structs::vpx_bool_writer::VPXBoolWriter;
-use crate::Result;
 
 #[inline(never)] // don't inline so that the profiler can get proper data
 pub fn lepton_encode_row_range<W: Write>(
@@ -459,11 +459,7 @@ fn encode_edge<W: Write, const ALL_PRESENT: bool>(
 }
 
 fn count_non_zero(v: i16) -> u8 {
-    if v == 0 {
-        0
-    } else {
-        1
-    }
+    if v == 0 { 0 } else { 1 }
 }
 
 fn encode_one_edge<W: Write, const ALL_PRESENT: bool, const HORIZONTAL: bool>(

--- a/lib/src/structs/lepton_file_reader.rs
+++ b/lib/src/structs/lepton_file_reader.rs
@@ -18,15 +18,15 @@ use crate::jpeg::block_based_image::BlockBasedImage;
 use crate::jpeg::jpeg_code;
 use crate::jpeg::jpeg_header::{JpegHeader, ReconstructionInfo, RestartSegmentCodingInfo};
 use crate::jpeg::jpeg_write::{jpeg_write_baseline_row_range, jpeg_write_entire_scan};
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode, Result};
+use crate::lepton_error::{AddContext, ExitCode, Result, err_exit_code};
 use crate::metrics::{CpuTimeMeasure, Metrics};
 use crate::structs::lepton_decoder::lepton_decode_row_range;
-use crate::structs::lepton_header::{LeptonHeader, FIXED_HEADER_SIZE};
+use crate::structs::lepton_header::{FIXED_HEADER_SIZE, LeptonHeader};
 use crate::structs::multiplexer::{MultiplexReader, MultiplexReaderState};
 use crate::structs::partial_buffer::PartialBuffer;
 use crate::structs::quantization_tables::QuantizationTables;
 use crate::structs::thread_handoff::ThreadHandoff;
-use crate::{consts::*, LeptonThreadPool};
+use crate::{LeptonThreadPool, consts::*};
 
 /// Reads an entire lepton file and writes it out as a JPEG
 ///

--- a/lib/src/structs/lepton_file_writer.rs
+++ b/lib/src/structs/lepton_file_writer.rs
@@ -17,7 +17,7 @@ use crate::jpeg::block_based_image::BlockBasedImage;
 use crate::jpeg::jpeg_header::JpegHeader;
 use crate::jpeg::jpeg_read::read_jpeg_file;
 use crate::jpeg::truncate_components::TruncateComponents;
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode, Result};
+use crate::lepton_error::{AddContext, ExitCode, Result, err_exit_code};
 use crate::metrics::{CpuTimeMeasure, Metrics};
 use crate::structs::lepton_encoder::lepton_encode_row_range;
 use crate::structs::lepton_file_reader::decode_lepton;
@@ -25,7 +25,7 @@ use crate::structs::lepton_header::LeptonHeader;
 use crate::structs::multiplexer::multiplex_write;
 use crate::structs::quantization_tables::QuantizationTables;
 use crate::structs::thread_handoff::ThreadHandoff;
-use crate::{consts::*, LeptonThreadPool, StreamPosition};
+use crate::{LeptonThreadPool, StreamPosition, consts::*};
 
 /// Reads a jpeg and writes it out as a lepton file
 ///

--- a/lib/src/structs/lepton_header.rs
+++ b/lib/src/structs/lepton_header.rs
@@ -3,16 +3,16 @@ use std::io::{Cursor, ErrorKind, Read, Seek, Write};
 
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use default_boxed::DefaultBoxed;
+use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
-use flate2::Compression;
 
+use crate::EnabledFeatures;
 use crate::consts::*;
 use crate::helpers::buffer_prefix_matches_marker;
 use crate::jpeg::jpeg_header::{JpegHeader, ReconstructionInfo};
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode, Result};
+use crate::lepton_error::{AddContext, ExitCode, Result, err_exit_code};
 use crate::structs::thread_handoff::ThreadHandoff;
-use crate::EnabledFeatures;
 
 pub const FIXED_HEADER_SIZE: usize = 28;
 

--- a/lib/src/structs/model.rs
+++ b/lib/src/structs/model.rs
@@ -11,7 +11,7 @@ use default_boxed::DefaultBoxed;
 
 use crate::consts::*;
 use crate::helpers::{calc_sign_index, u16_bit_length, u32_bit_length};
-use crate::lepton_error::{err_exit_code, AddContext, ExitCode, Result};
+use crate::lepton_error::{AddContext, ExitCode, Result, err_exit_code};
 use crate::metrics::{ModelComponent, ModelSubComponent};
 use crate::structs::branch::Branch;
 use crate::structs::quantization_tables::QuantizationTables;

--- a/lib/src/structs/multiplexer.rs
+++ b/lib/src/structs/multiplexer.rs
@@ -2,7 +2,7 @@ use std::cmp;
 use std::collections::VecDeque;
 use std::io::{Cursor, Read, Write};
 use std::mem::swap;
-use std::sync::mpsc::{channel, Receiver, Sender};
+use std::sync::mpsc::{Receiver, Sender, channel};
 use std::sync::{Arc, Mutex};
 
 use byteorder::WriteBytesExt;
@@ -79,10 +79,10 @@ impl<RESULT> ThreadResults<RESULT> {
     }
     /// creates a closure that wraps the passed in closure, catches any panics,
     /// collects the return result and send it to the receiver to collect.
-    fn send_results(
+    fn send_results<T: FnOnce() -> Result<RESULT> + Send + 'static>(
         &mut self,
-        f: impl FnOnce() -> Result<RESULT> + Send + 'static,
-    ) -> impl FnOnce() {
+        f: T,
+    ) -> impl FnOnce() + use<RESULT, T> {
         let (tx, rx) = channel();
 
         self.results.push(rx);

--- a/lib/src/structs/quantization_tables.rs
+++ b/lib/src/structs/quantization_tables.rs
@@ -76,9 +76,9 @@ impl QuantizationTables {
             for i in [0, 1, 2, 3, 4, 5, 6, 7, 8, 16, 24, 32, 40, 48, 56] {
                 if qtables.get_quantization_table()[i] == 0 {
                     return err_exit_code(
-                    ExitCode::UnsupportedJpegWithZeroIdct0,
-                    "Quantization table contains zero for edge which would cause a divide by zero",
-                );
+                        ExitCode::UnsupportedJpegWithZeroIdct0,
+                        "Quantization table contains zero for edge which would cause a divide by zero",
+                    );
                 }
             }
             quantization_tables.push(qtables);

--- a/lib/src/structs/simple_threadpool.rs
+++ b/lib/src/structs/simple_threadpool.rs
@@ -13,8 +13,8 @@
 /// No unsafe code is used.
 use std::{
     sync::{
-        mpsc::{channel, Sender},
         LazyLock, Mutex,
+        mpsc::{Sender, channel},
     },
     thread::{self, spawn},
 };
@@ -133,8 +133,8 @@ static NUM_CPUS: LazyLock<usize> = LazyLock::new(|| thread::available_parallelis
 
 #[test]
 fn test_threadpool() {
-    use std::sync::atomic::{AtomicU32, Ordering};
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, Ordering};
 
     let a: Arc<AtomicU32> = Arc::new(AtomicU32::new(0));
 

--- a/lib/src/structs/vpx_bool_reader.rs
+++ b/lib/src/structs/vpx_bool_reader.rs
@@ -25,7 +25,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS “AS IS” 
 use std::io::{Read, Result};
 
 use crate::lepton_error;
-use crate::lepton_error::{err_exit_code, ExitCode};
+use crate::lepton_error::{ExitCode, err_exit_code};
 use crate::metrics::{Metrics, ModelComponent};
 use crate::structs::branch::Branch;
 use crate::structs::simple_hash::SimpleHash;

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -10,7 +10,7 @@ use std::io::{Cursor, Read};
 use std::path::Path;
 
 use lepton_jpeg::{
-    decode_lepton, encode_lepton, encode_lepton_verify, EnabledFeatures, DEFAULT_THREAD_POOL,
+    DEFAULT_THREAD_POOL, EnabledFeatures, decode_lepton, encode_lepton, encode_lepton_verify,
 };
 use lepton_jpeg::{ExitCode, LeptonError};
 use rstest::rstest;

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lepton_jpeg_util"
-version = "0.5.4"
-edition = "2021"
+version = "0.5.5"
+edition = "2024"
 authors = ["Kristof Roomp <kristofr@microsoft.com>"]
 rust-version = "1.85"
 

--- a/util/src/main.rs
+++ b/util/src/main.rs
@@ -6,16 +6,16 @@
 
 use std::borrow::Cow;
 use std::ffi::OsStr;
-use std::fs::{remove_file, File, OpenOptions};
-use std::io::{stdin, stdout, Cursor, IsTerminal, Read, Seek, Write};
+use std::fs::{File, OpenOptions, remove_file};
+use std::io::{Cursor, IsTerminal, Read, Seek, Write, stdin, stdout};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
 
 use lepton_jpeg::{
-    decode_lepton, dump_jpeg, encode_lepton, encode_lepton_verify, CpuTimeMeasure, EnabledFeatures,
-    ExitCode, LeptonError, LeptonThreadPool, LeptonThreadPriority, Metrics, SimpleThreadPool,
-    DEFAULT_THREAD_POOL,
+    CpuTimeMeasure, DEFAULT_THREAD_POOL, EnabledFeatures, ExitCode, LeptonError, LeptonThreadPool,
+    LeptonThreadPriority, Metrics, SimpleThreadPool, decode_lepton, dump_jpeg, encode_lepton,
+    encode_lepton_verify,
 };
 use log::{error, info};
 use simple_logger::SimpleLogger;


### PR DESCRIPTION
Only some minor formatting changes and warnings fixes. There is one change that requires more explicit lifetimes.

Most of the changes are due to Rust now alphabetically ordering imports.