### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,8 @@
 name: Rust
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ["main"]


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/lepton_jpeg_rust/security/code-scanning/2](https://github.com/microsoft/lepton_jpeg_rust/security/code-scanning/2)

The fix involves adding a `permissions` block that explicitly sets the minimum required permissions for the workflow job(s). Since the job shown only checks out code and builds/tests it, it requires only read access to the repository contents. The best fix is to add a `permissions:` block at the root level of the workflow file (above `jobs:`) and set `contents: read`. This will ensure all jobs in the workflow inherit these minimal permissions unless further overridden. No imports or other sections need changes: the fix is limited to adding a YAML stanza in `.github/workflows/rust.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
