### PR TITLE
fix slash in publish

### DIFF
--- a/.github/workflows/publishwheels.yml
+++ b/.github/workflows/publishwheels.yml
@@ -60,6 +60,6 @@ jobs:
           fi
 
           cd python
-          maturin upload --skip-existing ${{ github.workspace }}/target/wheels/*
+          maturin upload --skip-existing $GITHUB_WORKSPACE/target/wheels/*
         env:
           MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}  


### PR DESCRIPTION
Windows uses forward slashes that break. Use env variable that has the right slashes.