### PR TITLE
use version from root file instead of lib for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,7 @@ jobs:
     - name: Read version from Cargo.toml
       id: cargo_version
       run: |
-        CARGO_VERSION=$(grep '^version\s*=' lib/Cargo.toml | head -1 | sed -E 's/version\s*=\s*"([^"]+)"/\1/')
+        CARGO_VERSION=$(grep '^version\s*=' Cargo.toml | head -1 | sed -E 's/version\s*=\s*"([^"]+)"/\1/')
         echo "CARGO_VERSION=$CARGO_VERSION" >> "$GITHUB_OUTPUT"
 
     - name: Check tag version matches Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -57,6 +57,10 @@ jobs:
         run: |
           cargo nextest run --workspace --profile ci
 
+      # Verify the crate can be published without actually publishing
+      - name: Publish dry run
+        run: cargo publish --dry-run --package lepton_jpeg
+
       # Upload test results so GitHub shows pass/fail per test
       - name: Upload test results
         uses: EnricoMi/publish-unit-test-result-action/windows@v2


### PR DESCRIPTION
Version# is now centralized at the root crate using workspace versioning, so use that for publish determination that we have the right version.